### PR TITLE
prefer persisted? to new_record?

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -323,8 +323,12 @@ module Formtastic #:nodoc:
       options = args.extract_options!
       text = options.delete(:label) || args.shift
 
-      if @object && @object.respond_to?(:new_record?)
-        key = @object.new_record? ? :create : :update
+      if @object && (@object.respond_to?(:persisted?) || @object.respond_to?(:new_record?))
+        if @object.respond_to?(:persisted?) # ActiveModel
+          key = @object.persisted? ? :update : :create
+        else # Rails 2
+          key = @object.new_record? ? :create : :update
+        end
 
         # Deal with some complications with ActiveRecord::Base.human_name and two name models (eg UserPost)
         # ActiveRecord::Base.human_name falls back to ActiveRecord::Base.name.humanize ("Userpost")

--- a/spec/commit_button_spec.rb
+++ b/spec/commit_button_spec.rb
@@ -10,6 +10,43 @@ describe 'SemanticFormBuilder#commit_button' do
     mock_everything
   end
 
+  describe 'when the object responds to :new_record? (Rails 2)' do
+    
+    before do
+      @new_post.stub(:respond_to?).with(:to_model).and_return("X")
+      @new_post.stub(:respond_to?).with(:persisted?).and_return(false)
+      @new_post.stub(:respond_to?).with(:new_record?).and_return(true)
+    end
+    
+    it 'should call :new_record?' do
+      @new_post.should_receive(:new_record?)
+      @new_post.should_not_receive(:persisted?)
+      semantic_form_for(@new_post) do |builder|
+        concat(builder.commit_button)
+      end
+    end
+    
+  end
+  
+  describe 'when the object responds to :persisted? (ActiveModel)' do
+    
+    before do
+      @new_post.stub(:respond_to?).with(:to_model).and_return("X")
+      @new_post.stub(:respond_to?).with(:persisted?).and_return(true)
+      @new_post.stub(:respond_to?).with(:new_record?).and_return(false)
+    end
+    
+    it 'should call :persisted?' do
+      @new_post.should_receive(:persisted?)
+      @new_post.should_not_receive(:new_record?)
+      semantic_form_for(@new_post) do |builder|
+        concat(builder.commit_button)
+      end
+    end
+    
+  end
+  
+
   describe 'when used on any record' do
 
     before do
@@ -287,7 +324,7 @@ describe 'SemanticFormBuilder#commit_button' do
     # Existing record
     describe 'when used on an existing record' do
       before do
-        @new_post.stub!(:new_record?).and_return(false)
+        @new_post.stub!(:persisted?).and_return(true)
       end
 
       describe 'when explicit label is provided' do


### PR DESCRIPTION
For maximum compatibility, it would be best to prefer the ActiveModel API (persisted?) to the ActiveRecord API (new_record?).

This is the pull request to replace http://github.com/justinfrench/formtastic/issues#issue/342.
