### PR TITLE
I18n bugfix

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -1745,7 +1745,9 @@ module Formtastic #:nodoc:
             action_name = template.params[:action].to_s rescue ''
             attribute_name = key.to_s
 
-            defaults = ::Formtastic::I18n::SCOPES.collect do |i18n_scope|
+            defaults = ::Formtastic::I18n::SCOPES.reject do |i18n_scope|
+              nested_model_name.nil? && i18n_scope.to_s.match(/\{nested_model\}/)
+            end.collect do |i18n_scope|
               i18n_path = i18n_scope.dup
               i18n_path.gsub!('%{action}', action_name)
               i18n_path.gsub!('%{model}', model_name)


### PR DESCRIPTION
Hi Justin,

The scopes being sent for i18n lookup seemed wrong while i was investigating ticket 376.

It was sending 

[:"post.%{nested_model}.published", :"post.published", :"post.%{nested_model}.published", :"post.published", :"%{nested_model}.published", :published] 

instead of

[:"post.published", :"post.published", :published]

When there are no nested models, it should not include them in the lookup, so it needs to rejected from scope list.

All specs pass.
