### PR TITLE
Error hints

### DIFF
--- a/generators/formtastic/templates/formtastic.rb
+++ b/generators/formtastic/templates/formtastic.rb
@@ -32,6 +32,12 @@
 # Set the way inline errors will be displayed.
 # Defaults to :sentence, valid options are :sentence, :list, :first and :none
 # Formtastic::SemanticFormBuilder.inline_errors = :sentence
+# Formtastic uses the following classes as default for hints, inline_errors and error list
+
+# If you override the class here, please ensure to override it in your formtastic_changes.css stylesheet as well
+# Formtastic::SemanticFormBuilder.default_hint_class = "inline-hints"
+# Formtastic::SemanticFormBuilder.default_inline_error_class = "inline-errors"
+# Formtastic::SemanticFormBuilder.default_error_list_class = "errors"
 
 # Set the method to call on label text to transform or format it for human-friendly
 # reading when formtastic is used without object. Defaults to :humanize.
@@ -55,7 +61,6 @@
 # fall back to the default order as defined by #inline_order
 # Formtastic::SemanticFormBuilder.custom_inline_order[:checkbox] = [:errors, :hints, :input]
 # Formtastic::SemanticFormBuilder.custom_inline_order[:select] = [:hints, :input, :errors]
-
 
 # Specifies if labels/hints for input fields automatically be looked up using I18n.
 # Default value: false. Overridden for specific fields by setting value to true,

--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -9,7 +9,7 @@ module Formtastic #:nodoc:
     class_inheritable_accessor :default_text_field_size, :default_text_area_height, :default_text_area_width, :all_fields_required_by_default, :include_blank_for_select_by_default,
                    :required_string, :optional_string, :inline_errors, :label_str_method, :collection_value_methods, :collection_label_methods,
                    :inline_order, :custom_inline_order, :file_methods, :priority_countries, :i18n_lookups_by_default, :escape_html_entities_in_hints_and_labels,
-                   :default_commit_button_accesskey, :instance_reader => false
+                   :default_commit_button_accesskey, :default_inline_error_class, :default_hint_class, :default_error_list_class, :instance_reader => false
 
     self.default_text_field_size = nil
     self.default_text_area_height = 20
@@ -29,6 +29,9 @@ module Formtastic #:nodoc:
     self.i18n_lookups_by_default = false
     self.escape_html_entities_in_hints_and_labels = true
     self.default_commit_button_accesskey = nil
+    self.default_inline_error_class = 'inline-errors'
+    self.default_error_list_class = 'errors'
+    self.default_hint_class = 'inline-hints'
 
     RESERVED_COLUMNS = [:created_at, :updated_at, :created_on, :updated_on, :lock_version, :version]
 
@@ -1258,20 +1261,21 @@ module Formtastic #:nodoc:
       def inline_hints_for(method, options) #:nodoc:
         options[:hint] = localized_string(method, options[:hint], :hint)
         return if options[:hint].blank? or options[:hint].kind_of? Hash
-        template.content_tag(:p, Formtastic::Util.html_safe(options[:hint]), :class => (options[:hint_class] ? options[:hint_class] : 'inline-hints'))
+        hint_class = options[:hint_class] || self.class.default_hint_class
+        template.content_tag(:p, Formtastic::Util.html_safe(options[:hint]), :class => hint_class)
       end
 
       # Creates an error sentence by calling to_sentence on the errors array.
       #
       def error_sentence(errors, options = {}) #:nodoc:
-        error_class = (options[:error_class]) ? options[:error_class] : 'inline-errors'
+        error_class = options[:error_class] || self.class.default_inline_error_class
         template.content_tag(:p, Formtastic::Util.html_safe(errors.to_sentence.untaint), :class => error_class)
       end
 
       # Creates an error li list.
       #
       def error_list(errors, options = {}) #:nodoc:
-        error_class = (options[:error_class]) ? options[:error_class] : 'errors'
+        error_class = options[:error_class] || self.class.default_error_list_class
         list_elements = []
         errors.each do |error|
           list_elements <<  template.content_tag(:li, Formtastic::Util.html_safe(error.untaint))
@@ -1282,7 +1286,7 @@ module Formtastic #:nodoc:
       # Creates an error sentence containing only the first error
       #
       def error_first(errors, options = {}) #:nodoc:
-        error_class = (options[:error_class]) ? options[:error_class] : 'inline-errors'
+        error_class = options[:error_class] || self.class.default_inline_error_class
         template.content_tag(:p, Formtastic::Util.html_safe(errors.first.untaint), :class => error_class)
       end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -18,10 +18,23 @@ describe 'SemanticFormBuilder#errors_on' do
       @errors.stub!(:[]).with(:title).and_return(@title_errors)
     end
 
+    after do
+      ::Formtastic::SemanticFormBuilder.default_inline_error_class = 'inline-errors'
+      ::Formtastic::SemanticFormBuilder.default_error_list_class = 'errors'
+    end
+
     it 'should render a paragraph with the errors joined into a sentence when inline_errors config is :sentence' do
       ::Formtastic::SemanticFormBuilder.inline_errors = :sentence
       semantic_form_for(@new_post) do |builder|
         builder.errors_on(:title).should have_tag('p.inline-errors', @title_errors.to_sentence)
+      end
+    end
+
+    it 'should render a paragraph with a overridden default class' do
+      ::Formtastic::SemanticFormBuilder.inline_errors = :sentence
+      ::Formtastic::SemanticFormBuilder.default_inline_error_class = 'better-errors'
+      semantic_form_for(@new_post) do |builder|
+        builder.errors_on(:title).should have_tag('p.better-errors', @title_errors.to_sentence)
       end
     end
 
@@ -38,6 +51,17 @@ describe 'SemanticFormBuilder#errors_on' do
         builder.errors_on(:title).should have_tag('ul.errors')
         @title_errors.each do |error|
           builder.errors_on(:title).should have_tag('ul.errors li', error)
+        end
+      end
+    end
+
+    it 'should render an unordered list with the class overridden default class' do
+      ::Formtastic::SemanticFormBuilder.inline_errors = :list
+      ::Formtastic::SemanticFormBuilder.default_error_list_class = "better-errors"
+      semantic_form_for(@new_post) do |builder|
+        builder.errors_on(:title).should have_tag('ul.better-errors')
+        @title_errors.each do |error|
+          builder.errors_on(:title).should have_tag('ul.better-errors li', error)
         end
       end
     end

--- a/spec/input_spec.rb
+++ b/spec/input_spec.rb
@@ -703,6 +703,11 @@ describe 'SemanticFormBuilder#input' do
     describe ':hint option' do
 
       describe 'when provided' do
+
+        after do
+          ::Formtastic::SemanticFormBuilder.default_hint_class = "inline-hints"
+        end
+
         it 'should be passed down to the paragraph tag' do
           hint_text = "this is the title of the post"
           form = semantic_form_for(@new_post) do |builder|
@@ -719,7 +724,17 @@ describe 'SemanticFormBuilder#input' do
           end
           output_buffer.concat(form) if Formtastic::Util.rails3?
           output_buffer.should have_tag("form li p.custom-hint-class", hint_text)
-				end
+        end
+
+        it 'should have a custom hint class defaulted for all forms' do
+          hint_text = "this is the title of the post"
+          ::Formtastic::SemanticFormBuilder.default_hint_class = "custom-hint-class"
+          form = semantic_form_for(@new_post) do |builder|
+            concat(builder.input(:title, :hint => hint_text))
+          end
+          output_buffer.concat(form) if Formtastic::Util.rails3?
+          output_buffer.should have_tag("form li p.custom-hint-class", hint_text)
+        end
       end
 
       describe 'when not provided' do


### PR DESCRIPTION
Another shot at default error and hint classes. 

Shifted to class level defaults. Can now be updated on a form level as well.
