### PR TITLE
id_prefix changed to namespace

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -165,7 +165,7 @@ If you want to customize the label text, or render some hint text below the fiel
     <% form.inputs :name => "Advanced Options", :id => "advanced" do %>
       <%= form.input :slug, :label => "URL Title", :hint => "Created automatically if left blank", :required => false %>
       <%= form.input :section, :as => :radio %>
-      <%= form.input :user, :label => "Author", :label_method => :full_name,  %>
+      <%= form.input :user, :label => "Author", :label_method => :full_name %>
       <%= form.input :categories, :required => false %>
       <%= form.input :created_at, :as => :string, :label => "Publication Date", :required => false %>
     <% end %>
@@ -207,6 +207,17 @@ When working in has many association, you can even supply @"%i"@ in your fieldse
   <% end %>
 </pre>
 
+If you have more than one form on the same page, it may lead to HTML invalidation because of the way HTML element id attributes are assigned. You can provide
+a namespace for your form to ensure uniqueness of id attributes on form elements. The namespace attribute will be prefixed with underscore on the generate html id. For example:
+
+<pre>
+  <% semantic_form_for(@post, :namespace => 'cat_form') do |form| %>
+  <%= form.input :title %>        # id="cat_form_post_title"
+  <%= form.input :body %>         # id="cat_form_post_body"
+  <%= form.input :created_at %>   # id="cat_form_post_created_at"
+  <%= form.buttons %>
+  <% end %>
+</pre>
 
 Customize HTML attributes for any input using the @:input_html@ option. Typically this is used to disable the input, change the size of a text field, change the rows in a textarea, or even to add a special class to an input to attach special behavior like "autogrow":http://plugins.jquery.com/project/autogrow textareas:
 
@@ -230,7 +241,7 @@ The same can be done for buttons with the @:button_html@ option:
   <% end %>
 </pre>
 
-Customize the HTML attributes for the @<li>@ wrapper around every input with the @:wrapper_html@ option hash. There's one special key in the hash (@:class@), which will actually _append_ your string of classes to the existing classes provided by Formtastic (like @"required string error"@)
+Customize the HTML attributes for the @<li>@ wrapper around every input with the @:wrapper_html@ option hash. There's one special key in the hash (@:class@), which will actually _append_ your string of classes to the existing classes provided by Formtastic (like @"required string error"@).
 
 <pre>
   <% semantic_form_for @post do |form| %>
@@ -238,6 +249,14 @@ Customize the HTML attributes for the @<li>@ wrapper around every input with the
     <%= form.input :body %>
     <%= form.input :description, :wrapper_html => { :style => "display:none;" } %>
     ...
+  <% end %>
+</pre>
+
+Customize the default class used for hints on each attribute or globally in the @config/formtastic.rb@ file. Similarly you can customize the error classes on an attribute level or globally.
+
+<pre>
+  <% semantic_form_for @post do |form| %>
+    <%= form.input :title, :hint_class => 'custom-html-class', :error_class => 'custom-error-class' %>
   <% end %>
 </pre>
 

--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -11,7 +11,7 @@ module Formtastic #:nodoc:
                    :inline_order, :custom_inline_order, :file_methods, :priority_countries, :i18n_lookups_by_default, :escape_html_entities_in_hints_and_labels,
                    :default_commit_button_accesskey, :default_inline_error_class, :default_hint_class, :default_error_list_class, :instance_reader => false
 
-    cattr_accessor :custom_id_prefix
+    cattr_accessor :custom_namespace
 
     self.default_text_field_size = nil
     self.default_text_area_height = 20
@@ -1256,7 +1256,7 @@ module Formtastic #:nodoc:
 
         #input = self.check_box(method, strip_formtastic_options(options).merge(html_options),
         #                       checked_value, unchecked_value)
-        field_id = [@@custom_id_prefix,@object_name,method].reject{|x|x.blank?}.join("_")
+        field_id = [@@custom_namespace,@object_name,method].reject{|x|x.blank?}.join("_")
         input = template.check_box_tag(
           "#{@object_name}[#{method}]", 
           checked_value, 
@@ -1707,7 +1707,7 @@ module Formtastic #:nodoc:
                 end
         sanitized_method_name = method_name.to_s.gsub(/[\?\/\-]$/, '')
 
-        [@@custom_id_prefix, sanitized_object_name, index, sanitized_method_name, value].reject{|x|x.blank?}.join('_')
+        [@@custom_namespace, sanitized_object_name, index, sanitized_method_name, value].reject{|x|x.blank?}.join('_')
       end
 
       # Gets the nested_child_index value from the parent builder. In Rails 2.3
@@ -1913,7 +1913,7 @@ module Formtastic #:nodoc:
           options = args.extract_options!
           options[:builder] ||= @@builder
           options[:html] ||= {}
-          @@builder.custom_id_prefix = options[:id_prefix].to_s
+          @@builder.custom_namespace = options[:namespace].to_s
 
           singularizer = defined?(ActiveModel::Naming.singular) ? ActiveModel::Naming.method(:singular) : ActionController::RecordIdentifier.method(:singular_class_name)
 

--- a/spec/form_helper_spec.rb
+++ b/spec/form_helper_spec.rb
@@ -132,10 +132,10 @@ describe 'SemanticFormHelper' do
       end
     end
 
-    describe 'with :id_prefix option' do
-      it "should set the custom_id_prefix" do
-        semantic_form_for(@new_post, :id_prefix => 'context2') do |builder|
-          builder.custom_id_prefix == 'context2'
+    describe 'with :namespace option' do
+      it "should set the custom_namespace" do
+        semantic_form_for(@new_post, :namespace => 'context2') do |builder|
+          builder.custom_namespace == 'context2'
         end
       end
     end

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -64,13 +64,13 @@ describe 'boolean input' do
     output_buffer.should have_tag('form li label input[@name="project[allow_comments]"]')
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
       @output_buffer = ''
       mock_everything
 
-      @form = semantic_form_for(@new_post, :id_prefix => "context2") do |builder|
+      @form = semantic_form_for(@new_post, :namespace => "context2") do |builder|
         concat(builder.input(:allow_comments, :as => :boolean))
       end
     end

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -362,13 +362,13 @@ describe 'check_boxes input' do
     end
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
       @output_buffer = ''
       mock_everything
 
-      @form = semantic_form_for(@fred, :id_prefix => "context2") do |builder|
+      @form = semantic_form_for(@fred, :namespace => "context2") do |builder|
         concat(builder.input(:posts, :as => :check_boxes))
       end
     end

--- a/spec/inputs/country_input_spec.rb
+++ b/spec/inputs/country_input_spec.rb
@@ -78,13 +78,13 @@ describe 'country input' do
 
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
       @output_buffer = ''
       mock_everything
 
-      @form = semantic_form_for(@new_post, :id_prefix => 'context2') do |builder|
+      @form = semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         builder.stub!(:country_select).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
         builder.should_receive(:country_select).with(:country, [], {}, {:id => "context2_post_country"}).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
         concat(builder.input(:country, :priority_countries => []))

--- a/spec/inputs/date_input_spec.rb
+++ b/spec/inputs/date_input_spec.rb
@@ -57,11 +57,11 @@ describe 'date input' do
     end
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
       output_buffer.replace ''
-      @form = semantic_form_for(@new_post, :id_prefix => "context2") do |builder|
+      @form = semantic_form_for(@new_post, :namespace => "context2") do |builder|
         concat(builder.input(:publish_at, :as => :date, :order => [:year, :month, :day]))
       end
     end

--- a/spec/inputs/datetime_input_spec.rb
+++ b/spec/inputs/datetime_input_spec.rb
@@ -190,11 +190,11 @@ describe 'datetime input' do
   #
   #end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
       output_buffer.replace ''
-      @form = semantic_form_for(@new_post, :id_prefix => "context2") do |builder|
+      @form = semantic_form_for(@new_post, :namespace => "context2") do |builder|
         concat(builder.input(:created_at, :as => :datetime, :include_seconds => true))
       end
     end

--- a/spec/inputs/email_input_spec.rb
+++ b/spec/inputs/email_input_spec.rb
@@ -27,10 +27,10 @@ describe 'email input' do
 
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
-      @form = semantic_form_for(@new_post, :id_prefix => 'context2') do |builder|
+      @form = semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         concat(builder.input(:email))
       end
     end

--- a/spec/inputs/file_input_spec.rb
+++ b/spec/inputs/file_input_spec.rb
@@ -30,13 +30,13 @@ describe 'file input' do
     output_buffer.should have_tag("form li input.myclass")
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
       @output_buffer = ''
       mock_everything
 
-      @form = semantic_form_for(@new_post, :id_prefix => 'context2') do |builder|
+      @form = semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         concat(builder.input(:body, :as => :file))
       end
     end

--- a/spec/inputs/hidden_input_spec.rb
+++ b/spec/inputs/hidden_input_spec.rb
@@ -74,13 +74,13 @@ describe 'hidden input' do
     output_buffer.should_not have_tag("form li ul.hints")
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
       @output_buffer = ''
       mock_everything
 
-      @form = semantic_form_for(@new_post, :id_prefix => 'context2') do |builder|
+      @form = semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         concat(builder.input(:secret, :as => :hidden))
         concat(builder.input(:author_id, :as => :hidden, :value => 99))
         concat(builder.input(:published, :as => :hidden, :input_html => {:value => true}))

--- a/spec/inputs/numeric_input_spec.rb
+++ b/spec/inputs/numeric_input_spec.rb
@@ -41,9 +41,9 @@ describe 'numeric input' do
     it_should_have_input_with_name("project[title]")
   end
 
-  describe "when id_prefix provided" do
+  describe "when namespace provided" do
     before do
-      @form = semantic_form_for(@new_post, :id_prefix => :context2) do |builder|
+      @form = semantic_form_for(@new_post, :namespace => :context2) do |builder|
         concat(builder.input(:title, :as => :numeric))
       end
     end

--- a/spec/inputs/password_input_spec.rb
+++ b/spec/inputs/password_input_spec.rb
@@ -42,10 +42,10 @@ describe 'password input' do
     it_should_have_input_with_name("project[title]")
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
-      @form = semantic_form_for(@new_post, :id_prefix => "context2") do |builder|
+      @form = semantic_form_for(@new_post, :namespace => "context2") do |builder|
         concat(builder.input(:title, :as => :password))
       end
     end

--- a/spec/inputs/phone_input_spec.rb
+++ b/spec/inputs/phone_input_spec.rb
@@ -27,10 +27,10 @@ describe 'phone input' do
 
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
-      @form = semantic_form_for(@new_post, :id_prefix => "context2") do |builder|
+      @form = semantic_form_for(@new_post, :namespace => "context2") do |builder|
         concat(builder.input(:phone))
       end
     end

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -213,11 +213,11 @@ describe 'radio input' do
     end
   end
 
-  describe "when :id_prefix is given on form" do
+  describe "when :namespace is given on form" do
     before do
       @output_buffer = ''
       @new_post.stub!(:author_ids).and_return(nil)
-      @form = semantic_form_for(@new_post, :id_prefix => "custom_prefix") do |builder|
+      @form = semantic_form_for(@new_post, :namespace => "custom_prefix") do |builder|
         concat(builder.input(:authors, :as => :radio, :label => ''))
       end
 

--- a/spec/inputs/search_input_spec.rb
+++ b/spec/inputs/search_input_spec.rb
@@ -27,10 +27,10 @@ describe 'search input' do
 
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
-      @form = semantic_form_for(@new_post, :id_prefix => "context2") do |builder|
+      @form = semantic_form_for(@new_post, :namespace => "context2") do |builder|
         concat(builder.input(:search))
       end
     end

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -515,9 +515,9 @@ describe 'select input' do
     end
   end
 
-  describe 'when a id_prefix is provided' do
+  describe 'when a namespace is provided' do
     before do
-      @form = semantic_form_for(@freds_post, :id_prefix => 'context2') do |builder|
+      @form = semantic_form_for(@freds_post, :namespace => 'context2') do |builder|
         concat(builder.input(:authors, :as => :select))
       end
     end

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -138,10 +138,10 @@ describe 'string input' do
     end
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
-      @form = semantic_form_for(@new_post, :id_prefix => 'context2') do |builder|
+      @form = semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         concat(builder.input(:title, :as => :string))
       end
     end

--- a/spec/inputs/text_input_spec.rb
+++ b/spec/inputs/text_input_spec.rb
@@ -68,13 +68,13 @@ describe 'text input' do
     output_buffer.should_not have_tag("form li textarea[@rows]")
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
       @output_buffer = ''
       mock_everything
 
-      @form = semantic_form_for(@new_post, :id_prefix => 'context2') do |builder|
+      @form = semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         concat(builder.input(:body, :as => :text))
       end
     end

--- a/spec/inputs/time_input_spec.rb
+++ b/spec/inputs/time_input_spec.rb
@@ -138,14 +138,14 @@ describe 'time input' do
     end
   end
 
-  describe ':id_prefix option' do
+  describe ':namespace option' do
     before do
-      @form = semantic_form_for(@new_post, :id_prefix => 'form2') do |builder|
+      @form = semantic_form_for(@new_post, :namespace => 'form2') do |builder|
         concat(builder.input(:publish_at, :as => :time))
       end
     end
 
-    it 'should have a tag matching the id_prefix' do
+    it 'should have a tag matching the namespace' do
       output_buffer.concat(@form) if Formtastic::Util.rails3?
       output_buffer.should have_tag('#form2_post_publish_at_input')
       output_buffer.should have_tag('#form2_post_publish_at_4i')

--- a/spec/inputs/time_zone_input_spec.rb
+++ b/spec/inputs/time_zone_input_spec.rb
@@ -40,13 +40,13 @@ describe 'time_zone input' do
     output_buffer.should have_tag("form li select.myclass")
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
       @output_buffer = ''
       mock_everything
 
-      @form = semantic_form_for(@new_post, :id_prefix => 'context2') do |builder|
+      @form = semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         concat(builder.input(:time_zone))
       end
     end

--- a/spec/inputs/url_input_spec.rb
+++ b/spec/inputs/url_input_spec.rb
@@ -27,10 +27,10 @@ describe 'url input' do
 
   end
 
-  describe "when id_prefix is provided" do
+  describe "when namespace is provided" do
 
     before do
-      @form = semantic_form_for(@new_post, :id_prefix => "context2") do |builder|
+      @form = semantic_form_for(@new_post, :namespace => "context2") do |builder|
         concat(builder.input(:url))
       end
     end

--- a/spec/semantic_fields_for_spec.rb
+++ b/spec/semantic_fields_for_spec.rb
@@ -41,9 +41,9 @@ describe 'SemanticFormBuilder#semantic_fields_for' do
     # <=> output_buffer.should_not have_tag('form fieldset.inputs #post[author]_1_login_input')
   end
 
-  it 'should use id_prefix provided in nested fields' do
+  it 'should use namespace provided in nested fields' do
     @bob.stub!(:column_for_attribute).and_return(mock('column', :type => :string, :limit => 255))
-    form = semantic_form_for(@new_post, :id_prefix => 'context2') do |builder|
+    form = semantic_form_for(@new_post, :namespace => 'context2') do |builder|
       concat(builder.semantic_fields_for(@bob, :index => 1) do |nested_builder|
         concat(nested_builder.inputs(:login))
       end)


### PR DESCRIPTION
Added documentation regarding form namespace, error_class and hint_class.
Renamed id_prefix to namespace.
