### PR TITLE
Error method

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -478,13 +478,6 @@ You can show errors on base (by default) and any other attribute just passing it
   <% end %>
 </pre>
 
-If you want to include inline errors on fields including the original field (for e.g. Paperclip adds errors on @:document_file_name@@ and @:document_file_size@ and @:document_content_type@ instead of @:document@), provide one or more keys with @:errors_on@ option
-
-<pre>
-  <% semantic_form_for @post do |form| %>
-    <%= form.input :document, :errors_on => [:document_file_size, :document_file_name] %>
-  <% end %>
-</pre>
 
 h2. ValidationReflection plugin
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -129,42 +129,21 @@ describe 'SemanticFormBuilder#errors_on' do
     end
   end
 
-  describe "when error keys are specified as options" do
-    it "should show errors on specified key" do
+  describe 'when file type columns have errors' do
+    it "should list errors added on metadata fields" do
       @errors.stub!(:[]).with(:document_file_name).and_return(['must be provided'])
-      @errors.stub!(:[]).with(:title).and_return([])
-      ::Formtastic::SemanticFormBuilder.inline_errors = :sentence
-      form = semantic_form_for(@new_post) do |builder|
-        builder.input(:title, :errors_on => :document_file_name)
-      end
-      output_buffer.concat(form) if Formtastic::Util.rails3?
-      output_buffer.should have_tag('p.inline-errors', (['must be provided']).to_sentence)
-      output_buffer.should have_tag("li[@class='string optional error']")
-    end
+      @errors.stub!(:[]).with(:document_file_size).and_return(['must be less than 4mb'])
+      @errors.stub!(:[]).with(:document_content_type).and_return(['must be an image'])
+      @errors.stub!(:[]).with(:document).and_return(nil)
 
-    it "should show errors on original method" do
-      @errors.stub!(:[]).with(:document_file_name).and_return(['must be provided'])
-      @errors.stub!(:[]).with(:title).and_return(@title_errors)
       ::Formtastic::SemanticFormBuilder.inline_errors = :sentence
       form = semantic_form_for(@new_post) do |builder|
-        builder.input(:title, :errors_on => :document_file_name)
+        builder.input(:document)
       end
-      output_buffer.concat(form) if Formtastic::Util.rails3?
-      output_buffer.should have_tag('p.inline-errors', (@title_errors+['must be provided']).to_sentence)
-      output_buffer.should have_tag("li[@class='string optional error']")
-    end
 
-    it "should show errors all specified keys" do
-      @errors.stub!(:[]).with(:document_file_name).and_return(['must be provided'])
-      @errors.stub!(:[]).with(:document_content_type).and_return(['must be an image file'])
-      @errors.stub!(:[]).with(:title).and_return(@title_errors)
-      ::Formtastic::SemanticFormBuilder.inline_errors = :sentence
-      form = semantic_form_for(@new_post) do |builder|
-        builder.input(:title, :errors_on => [:document_file_name, :document_content_type])
-      end
       output_buffer.concat(form) if Formtastic::Util.rails3?
-      output_buffer.should have_tag('p.inline-errors', (@title_errors+['must be provided', 'must be an image file']).to_sentence)
-      output_buffer.should have_tag("li[@class='string optional error']")
+      output_buffer.should have_tag("li[@class='file optional error']")
+      output_buffer.should have_tag('p.inline-errors', (['must be an image','must be provided', 'must be less than 4mb']).to_sentence)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -235,6 +235,11 @@ module FormtasticSpecHelper
     ::Post.stub!(:persisted?).and_return(nil)
     ::Post.stub!(:to_ary)
 
+    @mock_file = mock('file')
+    ::Formtastic::SemanticFormBuilder.file_methods.each do |method|
+      @mock_file.stub!(method).and_return(true)
+    end
+
     @new_post.stub!(:title)
     @new_post.stub!(:email)
     @new_post.stub!(:url)
@@ -256,6 +261,7 @@ module FormtasticSpecHelper
     @new_post.stub!(:country)
     @new_post.stub!(:country_subdivision)
     @new_post.stub!(:country_code)
+    @new_post.stub!(:document).and_return(@mock_file)
     @new_post.stub!(:column_for_attribute).with(:meta_description).and_return(mock('column', :type => :string, :limit => 255))
     @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :string, :limit => 50))
     @new_post.stub!(:column_for_attribute).with(:body).and_return(mock('column', :type => :text))
@@ -271,6 +277,7 @@ module FormtasticSpecHelper
     @new_post.stub!(:column_for_attribute).with(:url).and_return(mock('column', :type => :string, :limit => 255))
     @new_post.stub!(:column_for_attribute).with(:phone).and_return(mock('column', :type => :string, :limit => 255))
     @new_post.stub!(:column_for_attribute).with(:search).and_return(mock('column', :type => :string, :limit => 255))
+    @new_post.stub!(:column_for_attribute).with(:document).and_return(nil)
 
     @new_post.stub!(:author).and_return(@bob)
     @new_post.stub!(:author_id).and_return(@bob.id)

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -173,6 +173,9 @@ module CustomMacros
           @title_errors = ['must not be blank', 'must be longer than 10 characters', 'must be awesome']
           @errors = mock('errors')
           @errors.stub!(:[]).with(:title).and_return(@title_errors)
+          ::Formtastic::SemanticFormBuilder.file_metadata_suffixes.each do |suffix|
+            @errors.stub!(:[]).with("title_#{suffix}".to_sym).and_return(nil)
+          end
           @new_post.stub!(:errors).and_return(@errors)
         end
 


### PR DESCRIPTION
Hey guys,

Here's another pull requested with specs related to a problem i had and a small problem i saw in Formtastic.

Unfortunately, gems such as Paperclip, add errors on :document_file_name, :document_file_size, :document_content_type instead of :document which is their exposed field for interaction on the form. Thus if there are any problems on the file field, they are not visible without extra hackery. 

I've added an option called ":errors_on" which accepts one or more fields that can be provided to include inline errors on.

A small bug discovered and fixed was that if the error was on a field thru the belongs_to association, then the enclosing wrapper_html did not include the error class. This led to minor refactoring of code related to errors.

Updated documentation as well. Removed a stray 'puts' in tests.
