### PR TITLE
call to is_file? should pass options

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -1467,7 +1467,7 @@ module Formtastic #:nodoc:
           if @object
             return :select  if self.reflection_for(method)
 
-            return :file    if is_file?(method)
+            return :file    if is_file?(method, options)
           end
 
           return :select    if options.key?(:collection)


### PR DESCRIPTION
Although redundant at this point (since before calling it already looks at options[:as]), pass available options to is_file? call for completeness.

Sorry, I shouldve caught it before and if you feel its unnecessary, please do close the pull request.
