### PR TITLE
[Fix #451] Pass html options to checkbox tag

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -1241,20 +1241,20 @@ module Formtastic #:nodoc:
       # to the column name (method name) and can be altered with the :label option.
       # :checked_value and :unchecked_value options are also available.
       def boolean_input(method, options)
-        html_options = options.delete(:input_html) || {}
+        html_options  = options.delete(:input_html) || {}
         checked_value = options.delete(:checked_value) || '1'
         unchecked_value = options.delete(:unchecked_value) || '0'
 
-        field_id = generate_html_id(method, "")
+        html_options[:id] = html_options[:id] || generate_html_id(method, "")
         input = template.check_box_tag(
           "#{@object_name}[#{method}]",
           checked_value,
           (@object && @object.send(:"#{method}")),
-          :id => field_id
+          html_options
         )
         
         options = options_for_label(options)
-        options[:for] ||= field_id
+        options[:for] ||= html_options[:id]
 
         # the label() method will insert this nested input into the label at the last minute
         options[:label_prefix_for_nested_input] = input

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -37,23 +37,43 @@ describe 'boolean input' do
     output_buffer.should have_tag('form li label input[@type="checkbox"][@value="1"]')
   end
   
-  it 'should generate a checked checkbox input if object and object.method is true' do
+  it 'should generate a checked input if object.method returns true' do
     form = semantic_form_for(@new_post) do |builder|
       concat(builder.input(:allow_comments, :as => :boolean))
     end
 
     output_buffer.concat(form) if Formtastic::Util.rails3?
     output_buffer.should have_tag('form li label input[@checked="checked"]')
+    output_buffer.should have_tag('form li input[@name="post[allow_comments]"]', :count => 2)
+    output_buffer.should have_tag('form li input#post_allow_comments', :count => 1)
   end
   
-  it 'should generate a checked checkbox input if object and object.method is true' do
+  it 'should generate a checked input if :input_html is passed :checked => checked' do
     form = semantic_form_for(@new_post) do |builder|
-      concat(builder.input(:allow_comments, :as => :boolean))
+      concat(builder.input(:answer_comments, :as => :boolean, :input_html => {:checked => 'checked'}))
     end
 
     output_buffer.concat(form) if Formtastic::Util.rails3?
-    output_buffer.should have_tag('form li input[@name="post[allow_comments]"]', :count => 2)
-    output_buffer.should have_tag('form li input#post_allow_comments', :count => 1)
+    output_buffer.should have_tag('form li label input[@checked="checked"]')
+  end
+  
+  it "should generate a disabled input if :input_html is passed :disabled => 'disabled' " do
+    form = semantic_form_for(@new_post) do |builder|
+      concat(builder.input(:allow_comments, :as => :boolean, :input_html => {:disabled => 'disabled'}))
+    end
+    
+    output_buffer.concat(form) if Formtastic::Util.rails3?
+    output_buffer.should have_tag('form li label input[@disabled="disabled"]')
+  end
+  
+  it 'should generate an input[id] with matching label[for] when id passed in :input_html' do
+    form = semantic_form_for(@new_post) do |builder|
+      concat(builder.input(:allow_comments, :as => :boolean, :input_html => {:id => 'custom_id'}))
+    end
+    
+    output_buffer.concat(form) if Formtastic::Util.rails3?
+    output_buffer.should have_tag('form li label input[@id="custom_id"]')
+    output_buffer.should have_tag('form li label[@for="custom_id"]')
   end
 
   it 'should allow checked and unchecked values to be sent' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -250,6 +250,7 @@ module FormtasticSpecHelper
     @new_post.stub!(:time_zone)
     @new_post.stub!(:category_name)
     @new_post.stub!(:allow_comments).and_return(true)
+    @new_post.stub!(:answer_comments)
     @new_post.stub!(:country)
     @new_post.stub!(:country_subdivision)
     @new_post.stub!(:country_code)


### PR DESCRIPTION
You should be able to cherry-pick this and apply to 1.2-stable. If not let me know.
