### PR TITLE
Commit button disable_with option

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -359,6 +359,7 @@ module Formtastic #:nodoc:
 
       button_html = options.delete(:button_html) || {}
       button_html.merge!(:class => [button_html[:class], key].compact.join(' '))
+      button_html.merge!('data-disable-with' => options.delete(:disable_with)) if options[:disable_with]
 
       wrapper_html_class = ['commit'] # TODO: Add class reflecting on form action.
       wrapper_html = options.delete(:wrapper_html) || {}

--- a/spec/commit_button_spec.rb
+++ b/spec/commit_button_spec.rb
@@ -478,7 +478,29 @@ describe 'SemanticFormBuilder#commit_button' do
 
   end
 
-  
+  describe ':disable_with option' do
+    
+    describe 'when provided' do
+      it 'should add data-disable-with attribute to the button' do
+        form = semantic_form_for(@new_post) do |builder|
+          concat(builder.commit_button('text', :disable_with => "Submitting"))
+        end
+        output_buffer.concat(form) if Formtastic::Util.rails3?
+        output_buffer.should have_tag("form li input[data-disable-with=Submitting]")
+      end
+    end
+    
+    describe 'when not provided' do
+      it 'should not add the data-disable-with attribute to the button' do
+        form = semantic_form_for(@new_post) do |builder|
+          concat(builder.commit_button('text'))
+          output_buffer.concat(form) if Formtastic::Util.rails3?
+          output_buffer.should_not have_tag("li.commit input[data-disable-with]")
+        end
+      end
+    end
+    
+  end
   
   
 end


### PR DESCRIPTION
Rails supports :disable_with => "Text to display on button while submitting..." as an option to the form.submit and submit_tag methods.

This implementation is the same as is used in Rails 3 and hooks in to the rails.js stuff just fine.

Probably not compatible with old school non unobtrusive Rails 2 stuff though.
