### PR TITLE
Fixes Issue #468

### DIFF
--- a/lib/generators/formtastic/install/install_generator.rb
+++ b/lib/generators/formtastic/install/install_generator.rb
@@ -6,10 +6,8 @@ module Formtastic
     source_root File.expand_path('../../../templates', __FILE__)
 
     def copy_files
-      empty_directory 'config/initializers'
       template        'formtastic.rb', 'config/initializers/formtastic.rb'
 
-      empty_directory 'public/stylesheets'
       template        'formtastic.css',         'public/stylesheets/formtastic.css'
       template        'formtastic_changes.css', 'public/stylesheets/formtastic_changes.css'
     end


### PR DESCRIPTION
Fixes Issue #468 - https://github.com/justinfrench/formtastic/issues/#issue/468 - where the directories config/initializers and public/stylesheets are removed on running the destroy generator, regardless of other files that they contain.
