### PR TITLE
Changed formastic to formtastic in README.textile

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -563,7 +563,7 @@ h3. Generating a partial with @--partial@
 You can also ask Formtastic to *generate a partial* with the @--partial@ option, placing it in the correct location inside your @app/views@ directory:
 
 <pre>
-  $ rails generate formastic:form Post --partial
+  $ rails generate formtastic:form Post --partial
       exists  app/views/posts
       create  app/views/posts/_form.html.erb
 </pre>
@@ -571,7 +571,7 @@ You can also ask Formtastic to *generate a partial* with the @--partial@ option,
 h3. Specifying HAML instead of ERB with @--haml@
 
 <pre>
-  $ rails generate formastic:form Post --haml
+  $ rails generate formtastic:form Post --haml
       exists  app/views/admin/posts
       create  app/views/admin/posts/_form.html.haml
 </pre>
@@ -579,7 +579,7 @@ h3. Specifying HAML instead of ERB with @--haml@
 h3. Specifying controller namespace with @--controller@
 
 <pre>
-  $ rails generate formastic:form Post --partial --controller admin/posts
+  $ rails generate formtastic:form Post --partial --controller admin/posts
       exists  app/views/admin/posts
       create  app/views/admin/posts/_form.html.erb
 </pre>


### PR DESCRIPTION
Hi Justin,

Found few spelling mistakes in formtastic README.textile. Which I fixed and submitted.

e.g.

rails generate formastic:form Post --partial instead of  
rails generate formtastic:form Post --partial

Regards,
Rahul Trikha
