### PR TITLE
Change i18n version dependency from >= 0.4.0 to ~> 0.4

### DIFF
--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<activesupport>, [">= 2.3.7"])
   s.add_dependency(%q<actionpack>, [">= 2.3.7"])
-  s.add_dependency(%q<i18n>, [">= 0.4.0"])
+  s.add_dependency(%q<i18n>, ["~> 0.4"])
   
   if ENV['RAILS_2']
     s.add_development_dependency(%q<rails>, ["~> 2.3.8"])


### PR DESCRIPTION
i18n >= 0.5.0 is incompatible with rails 2.3.5, and this is the identical dependency that actionpack 3 itself specifies (http://rubygems.org/gems/actionpack), so it should result in both versions of rails getting the versions they're compatible with. 
