### PR TITLE
Use rails method to find out if a checkbox should be checked

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -1256,12 +1256,13 @@ module Formtastic #:nodoc:
         html_options  = options.delete(:input_html) || {}
         checked_value = options.delete(:checked_value) || '1'
         unchecked_value = options.delete(:unchecked_value) || '0'
+        checked = @object && ActionView::Helpers::InstanceTag.check_box_checked?(@object.send(:"#{method}"), checked_value)
 
         html_options[:id] = html_options[:id] || generate_html_id(method, "")
         input = template.check_box_tag(
           "#{@object_name}[#{method}]",
           checked_value,
-          (@object && @object.send(:"#{method}")),
+          checked,
           html_options
         )
         

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -83,6 +83,28 @@ describe 'boolean input' do
     output_buffer.should_not have_tag('form li label input[@type="hidden"]') # invalid HTML5
   end
 
+  it 'should generate a checked input if object.method returns checked value' do
+    @new_post.stub!(:allow_comments).and_return('yes')
+
+    form = semantic_form_for(@new_post) do |builder|
+      concat(builder.input(:allow_comments, :as => :boolean, :checked_value => 'yes', :unchecked_value => 'no'))
+    end
+
+    output_buffer.concat(form) if Formtastic::Util.rails3?
+    output_buffer.should have_tag('form li label input[@type="checkbox"][@value="yes"][@checked="checked"]')
+  end
+
+  it 'should not generate a checked input if object.method returns unchecked value' do
+    @new_post.stub!(:allow_comments).and_return('no')
+
+    form = semantic_form_for(@new_post) do |builder|
+      concat(builder.input(:allow_comments, :as => :boolean, :checked_value => 'yes', :unchecked_value => 'no'))
+    end
+
+    output_buffer.concat(form) if Formtastic::Util.rails3?
+    output_buffer.should have_tag('form li label input[@type="checkbox"][@value="yes"]:not([@checked])')
+  end
+
   it 'should generate a label and a checkbox even if no object is given' do
     form = semantic_form_for(:project, :url => 'http://test.host') do |builder|
       concat(builder.input(:allow_comments, :as => :boolean))


### PR DESCRIPTION
Rails has a sophisticated method for this purpose: https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/form_helper.rb#L1040 which I think should also be used in formtastic.

Current implementation doesn't work at least for custom checked and checked values, as it only checks if object.method returns true. I guess it also doesn't work for boolean attributes that are stored as integers if the database doesn't have a boolean data type (haven't tested it).
