### PR TITLE
Get select and radio working with mongoid

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -813,7 +813,7 @@ module Formtastic #:nodoc:
         html_options.delete(:multiple) if html_options[:multiple].nil?
 
         reflection = reflection_for(method)
-        if reflection && [ :has_many, :has_and_belongs_to_many ].include?(reflection.macro)
+        if reflection && [ :has_many, :has_and_belongs_to_many, :references_and_referenced_in_many ].include?(reflection.macro)
           html_options[:multiple] = true if html_options[:multiple].nil?
           html_options[:size]     ||= 5
           options[:include_blank] ||= false
@@ -1618,7 +1618,7 @@ module Formtastic #:nodoc:
       #
       def generate_association_input_name(method) #:nodoc:
         if reflection = reflection_for(method)
-          if [:has_and_belongs_to_many, :has_many].include?(reflection.macro)
+          if [:has_and_belongs_to_many, :has_many, :references_and_referenced_in_many].include?(reflection.macro)
             "#{method.to_s.singularize}_ids"
           else
             reflection.options[:foreign_key] || "#{method}_id"


### PR DESCRIPTION
select_input() and generate_association_input_name() both use reflection.macro to check for a habtm/has_many relationship. When using mongoid, reflection.macro returns :references_and_referenced_in_many for habtm relationships, which formtastic doesn't currently recognize.

My commit adds :references_and_referenced_in_many to the array of habtm/has_many reflections macros.

I wasn't sure if it would be 'better' to patch mongoid or formtastic, but I chose formtastic since the fix is simpler. 
