### PR TITLE
Check_boxes does not check values when using a non-association attribute

### DIFF
--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -171,6 +171,24 @@ describe 'check_boxes input' do
         output_buffer.should  =~ /&lt;b&gt;Item [12]&lt;\/b&gt;/
       end
     end
+    
+    describe 'for a non-association when :collection is given' do
+      before(:each) do
+        output_buffer.replace ''
+        
+        @fred.stub!(:genres) { [:biography, :fiction] }
+        
+        form = semantic_form_for(@fred, :url => 'http://test.host') do |builder|
+          concat(builder.input(:genres, :as => :check_boxes, :collection => [:fiction, :biography, :non_fiction]))
+        end
+        output_buffer.concat(form) if Formtastic::Util.rails3?
+      end
+      
+      it "should mark the correct options as checked" do
+        output_buffer.should have_tag("form li fieldset ol li label input[@name='author[genres][]'][@value='fiction'][@checked='checked']")
+        output_buffer.should have_tag("form li fieldset ol li label input[@name='author[genres][]'][@value='biography'][@checked='checked']")
+      end
+    end
 
     describe 'when :hidden_fields is set to false' do
       before do


### PR DESCRIPTION
I'm trying to make a collection of check boxes checked using a non-association attribute on my model. It goes kinda like this:

In the model:

```
 class Author < ...
     def genres
         [:fiction, :biography]
     end
 end
```

And in the view:

```
 <%= semantic_form_for @author ... do |f| %>
      <%= f.input :genres, :as => :check_boxes, :collection => [:fiction, :non_fiction, :biography] %>
 <% end %>
```

Formtastic outputs the check boxes, but none of them are checked. However, if I change the input type to select (:as => :select, :multiple => true), the options are selected correctly.

Attached is a pull request with a failing spec.
