### PR TITLE
Feature: ability to pass html options to radio input fieldset

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -6,20 +6,20 @@ require File.join(File.dirname(__FILE__), *%w[formtastic railtie]) if defined?(:
 module Formtastic #:nodoc:
 
   class SemanticFormBuilder < ActionView::Helpers::FormBuilder
-    
+
     configurables = [
       :default_text_field_size, :default_text_area_height, :default_text_area_width, :all_fields_required_by_default, :include_blank_for_select_by_default,
       :required_string, :optional_string, :inline_errors, :label_str_method, :collection_value_methods, :collection_label_methods, :file_metadata_suffixes,
       :inline_order, :custom_inline_order, :file_methods, :priority_countries, :i18n_lookups_by_default, :escape_html_entities_in_hints_and_labels,
       :default_commit_button_accesskey, :default_inline_error_class, :default_hint_class, :default_error_list_class
     ]
-    
+
     if respond_to?(:class_attribute)
       class_attribute *configurables
     else
       class_inheritable_accessor *configurables
     end
-    
+
     cattr_accessor :custom_namespace
 
     self.default_text_field_size = nil
@@ -109,7 +109,7 @@ module Formtastic #:nodoc:
     #
     def input(method, options = {})
       options = options.dup # Allow options to be shared without being tainted by Formtastic
-      
+
       options[:required] = method_required?(method) unless options.key?(:required)
       options[:as]     ||= default_input_type(method, options)
 
@@ -286,7 +286,7 @@ module Formtastic #:nodoc:
       html_options = args.extract_options!
       html_options[:class] ||= "inputs"
       html_options[:name] = title
-      
+
       if html_options[:for] # Nested form
         inputs_for_nested_attributes(*(args << html_options), &block)
       elsif block_given?
@@ -924,6 +924,7 @@ module Formtastic #:nodoc:
       def radio_input(method, options)
         collection   = find_collection_for_column(method, options)
         html_options = strip_formtastic_options(options).merge(options.delete(:input_html) || {})
+        fieldset_options = options.delete(:fieldset_html) || {}
 
         input_name = generate_association_input_name(method)
         value_as_class = options.delete(:value_as_class)
@@ -947,7 +948,8 @@ module Formtastic #:nodoc:
         end
 
         template.content_tag(:fieldset,
-          legend_tag(method, options) << template.content_tag(:ol, Formtastic::Util.html_safe(list_item_content.join))
+          legend_tag(method, options) << template.content_tag(:ol, Formtastic::Util.html_safe(list_item_content.join)),
+          fieldset_options
         )
       end
 
@@ -1265,7 +1267,7 @@ module Formtastic #:nodoc:
           checked,
           html_options
         )
-        
+
         options = options_for_label(options)
         options[:for] ||= html_options[:id]
 
@@ -1694,7 +1696,7 @@ module Formtastic #:nodoc:
         column = column_for(method)
 
         if type == :text
-          { :rows => default_text_area_height, 
+          { :rows => default_text_area_height,
             :cols => default_text_area_width }
         elsif type == :numeric || column.nil? || !column.respond_to?(:limit) || column.limit.nil?
           { :maxlength => validation_max_limit,

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -45,6 +45,14 @@ describe 'radio input' do
       output_buffer.should have_tag('form li input[@checked]', :count => 1)
     end
 
+    it "should take arbitrary html options for the wrapping fieldset" do
+      form = semantic_form_for(@new_post) do |builder|
+        concat(builder.input(:author, :as => :radio, :fieldset_html => {"data-foo" => "bar"}))
+      end
+      output_buffer.concat(form) if Formtastic::Util.rails3?
+      output_buffer.should have_tag("form li fieldset[@data-foo='bar']")
+    end
+
     describe "each choice" do
 
       it 'should contain a label for the radio input with a nested input and label text' do


### PR DESCRIPTION
Working with jquerymobile requires the ability to set attributes on the fieldset that contains the radio inputs.  Check it out:

http://jquerymobile.com/demos/1.0a3/#docs/forms/forms-radiobuttons.html

Spec added too.  Before I implemented, even.  :)
