### PR TITLE
Missing maxlength

### DIFF
--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -132,6 +132,10 @@ describe 'string input' do
           @new_post.should_receive(:specify_maxlength).at_least(1).and_return(false)
           should_have_maxlength(42, :options => { :maximum => 42, :unless => :specify_maxlength })
         end
+
+        it 'should have maxlength even if allow_blank is true' do
+          should_have_maxlength(42, :options => { :maximum => 42, :allow_blank => true })
+        end
       end
     end
   end


### PR DESCRIPTION
It seems whenever a validator on an attribute was declared to allow blank values, the maxlength attribute would not be set on the input field for that attribute.

So given a model:

```
class Post < ActiveRecord::Base
  validates :title, :length => {:maximum => 20}, :allow_blank => true
end
```

Formtastic used to return

```
<input id="post_title" maxlength="50" name="post[title]" type="text">
```

And with these changes it returns

```
<input id="post_title" maxlength="20" name="post[title]" type="text">
```
