### PR TITLE
Support Method objects for :label_method and :value_method.

### DIFF
--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -81,7 +81,7 @@ module Formtastic
         end
       
         def send_or_call(duck, object)
-          if duck.is_a?(Proc)
+          if duck.respond_to?(:call)
             duck.call(object)
           else
             object.send(duck)

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -408,6 +408,22 @@ module CustomMacros
             end
           end
 
+          describe 'as a method object' do
+            before do
+              def reverse_login(a)
+                a.login.reverse
+              end
+              concat(semantic_form_for(@new_post) do |builder|
+                concat(builder.input(:author, :as => as, :label_method => method(:reverse_login)))
+              end)
+            end
+
+            it 'should have options with the proc applied to each' do
+              ::Author.all.each do |author|
+                output_buffer.should have_tag("form li.#{as}", /#{author.login.reverse}/)
+              end
+            end
+          end
         end
 
         describe 'when the :label_method option is not provided' do
@@ -453,6 +469,23 @@ module CustomMacros
             before do
               concat(semantic_form_for(@new_post) do |builder|
                 concat(builder.input(:author, :as => as, :value_method => Proc.new {|a| a.login.reverse }))
+              end)
+            end
+
+            it 'should have options with the proc applied to each value' do
+              ::Author.all.each do |author|
+                output_buffer.should have_tag("form li.#{as} #{countable}[@value='#{author.login.reverse}']")
+              end
+            end
+          end
+
+          describe 'as a method object' do
+            before do
+              def reverse_login(a)
+                a.login.reverse
+              end
+              concat(semantic_form_for(@new_post) do |builder|
+                concat(builder.input(:author, :as => as, :value_method => method(:reverse_login)))
               end)
             end
 


### PR DESCRIPTION
Allows any object that responds to `:call` to be provided to :label_method and :value_method (attempts to quack the `duck` variable instead of checking if it's a Proc).

This allows you to use helper methods simply:

```
:label_method => method(:fancy_label)
```

Instead of the more verbose:

```
:label_method => Proc.new { |obj| fancy_label(obj) }
```

Additional specs provided.  All specs passing before the change pass after.  Happy to tweak based on feedback, thanks!
