### PR TITLE
Field should be always optional when :required is explicitly set to false.

### DIFF
--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -84,6 +84,8 @@ module Formtastic
         end
         
         def required?
+          return false if options[:required] == false
+          return true if options[:required] == true
           return false if not_required_through_negated_validation?
           if validations?
             validations.select { |validator| 
@@ -91,8 +93,6 @@ module Formtastic
               validator.options[:allow_blank] != true
             }.any?
           else
-            return false if options[:required] == false
-            return true if options[:required] == true
             return !!builder.all_fields_required_by_default
           end
         end

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -71,6 +71,17 @@ describe 'Formtastic::FormBuilder#input' do
           output_buffer.should have_tag('form li.optional')
         end
 
+        it 'should set and "optional" class also when there is presence validator' do
+          @new_post.class.should_receive(:validators_on).with(:title).any_number_of_times.and_return([
+            active_model_presence_validator([:title])
+          ])
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(:title, :required => false))
+          end)
+          output_buffer.should_not have_tag('form li.required')
+          output_buffer.should have_tag('form li.optional')
+        end
+
         it 'should append the "optional" string to the label' do
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:title, :required => false))


### PR DESCRIPTION
This will fix the following issue

```
class Post < ActiveRecord::Base
   validates_presence_of :title
   before_validation :generate_title
   ...
end
...
f.input :title, :required => false
```

If you explicitly set `:required` to `false` it will ignore this and set the field as required.

Google Chrome supports html5 `required` attribute and will not allow me to submit the form and currently there is no way to override this.
