### PR TITLE
Refactored associations. There is not Reflection#options for mongoid.

### DIFF
--- a/lib/formtastic/helpers/errors_helper.rb
+++ b/lib/formtastic/helpers/errors_helper.rb
@@ -94,7 +94,7 @@ module Formtastic
         @methods_for_error[method] ||= begin
           methods_for_error = [method.to_sym]
           methods_for_error << file_metadata_suffixes.map{|suffix| "#{method}_#{suffix}".to_sym} if is_file?(method, options)
-          methods_for_error << [association_primary_key(method)] if association_macro_for_method(method) == :belongs_to
+          methods_for_error << [association_primary_key_for_method(method)] if association_macro_for_method(method) == :belongs_to
           methods_for_error.flatten.compact.uniq
         end
       end
@@ -107,18 +107,6 @@ module Formtastic
       def render_inline_errors?
         @object && @object.respond_to?(:errors) && Formtastic::FormBuilder::INLINE_ERROR_TYPES.include?(inline_errors)
       end
-
-      def association_macro_for_method(method) #:nodoc:
-        reflection = reflection_for(method)
-        reflection.macro if reflection
-      end
-
-      def association_primary_key(method)
-        reflection = reflection_for(method)
-        reflection.options[:foreign_key] if reflection && !reflection.options[:foreign_key].blank?
-        :"#{method}_id"
-      end
-
     end
   end
 end

--- a/lib/formtastic/helpers/reflection.rb
+++ b/lib/formtastic/helpers/reflection.rb
@@ -7,6 +7,27 @@ module Formtastic
       def reflection_for(method) #:nodoc:
         @object.class.reflect_on_association(method) if @object.class.respond_to?(:reflect_on_association)
       end
+
+      def association_macro_for_method(method) #:nodoc:
+        reflection = reflection_for(method)
+        reflection.macro if reflection
+      end
+
+      def association_primary_key_for_method(method) #:nodoc:
+        reflection = reflection_for(method)
+        if reflection
+          case association_macro_for_method(method)
+          when :has_and_belongs_to_many, :has_many, :references_and_referenced_in_many, :references_many
+            :"#{method.to_s.singularize}_ids"
+          else
+            return reflection.foreign_key.to_sym if reflection.respond_to?(:foreign_key)
+            return reflection.options[:foreign_key].to_sym unless reflection.options[:foreign_key].blank?
+            :"#{method}_id"
+          end
+        else
+          method.to_sym
+        end
+      end
     end
   end
 end

--- a/lib/formtastic/inputs/base/associations.rb
+++ b/lib/formtastic/inputs/base/associations.rb
@@ -2,14 +2,15 @@ module Formtastic
   module Inputs
     module Base
       module Associations
+        include Formtastic::Helpers::Reflection
 
         # :belongs_to, etc
         def association
-          @association ||= reflection.macro if reflection
+          @association ||= association_macro_for_method(method)
         end
 
         def reflection
-          @reflection ||= object.class.reflect_on_association(method) if object.class.respond_to?(:reflect_on_association)
+          @reflection ||= reflection_for(method)
         end
 
         def belongs_to?
@@ -17,14 +18,7 @@ module Formtastic
         end
 
         def association_primary_key
-          if association
-            return reflection.options[:foreign_key] unless reflection.options[:foreign_key].blank?
-            return reflection.foreign_key if reflection.respond_to?(:foreign_key)
-            return :"#{method}_id" if belongs_to?
-            return "#{method.to_s.singularize}_id".pluralize.to_sym
-          else
-            return method.to_s
-          end
+          association_primary_key_for_method(method)
         end
 
       end

--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -54,11 +54,11 @@ module Formtastic
       
         def collection_from_association
           if reflection
-            raise PolymorphicInputWithoutCollectionError.new("A collection must be supplied for #{method} input. Collections cannot be guessed for polymorphic associations.") if reflection.options[:polymorphic] == true
+            raise PolymorphicInputWithoutCollectionError.new("A collection must be supplied for #{method} input. Collections cannot be guessed for polymorphic associations.") if reflection.options && reflection.options[:polymorphic] == true
 
             find_options_from_options = options[:find_options] || {}
             conditions_from_options = find_options_from_options[:conditions] || {}
-            conditions_from_reflection = reflection.options[:conditions] || {}
+            conditions_from_reflection = reflection.options && reflection.options[:conditions] || {}
             
             if conditions_from_options.any?
               reflection.klass.where(

--- a/lib/formtastic/inputs/base/naming.rb
+++ b/lib/formtastic/inputs/base/naming.rb
@@ -31,23 +31,11 @@ module Formtastic
             method.to_s.send(builder.label_str_method)
           end
         end
-        
-        # TODO this seems to overlap or be confused with association_primary_key
+
         def input_name
-          if reflection
-            if [:has_and_belongs_to_many, :has_many].include?(reflection.macro)
-              "#{method.to_s.singularize}_ids"
-            elsif reflection.respond_to? :foreign_key
-              reflection.foreign_key
-            else
-              reflection.options[:foreign_key] || "#{method}_id"
-            end
-          else
-            method
-          end.to_sym
+          association_primary_key
         end
-        
-      
+
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -218,7 +218,7 @@ module FormtasticSpecHelper
       when :main_post
         mock('reflection', :options => {}, :klass => ::Post, :macro => :belongs_to)
       when :mongoid_reviewer
-        mock('reflection', :options => {}, :klass => ::Author, :macro => :referenced_in, :foreign_key => "reviewer_id") # custom id
+        mock('reflection', :options => nil, :klass => ::Author, :macro => :referenced_in, :foreign_key => "reviewer_id") # custom id
       end
 
     end


### PR DESCRIPTION
Previously it was raising `NoMethodError` with select fields.

Example:

```
class Expert
  include Mongoid::Document
  belongs_to :user
end
...

f.input :user
...

NoMethodError:
  undefined method `[]' for nil:NilClass
# ./lib/formtastic/inputs/base/associations.rb:21:in `association_primary_key'
```
