### PR TITLE
Multiple selects need to have [] appended to their name attributes

### DIFF
--- a/lib/formtastic/inputs/select_input.rb
+++ b/lib/formtastic/inputs/select_input.rb
@@ -183,7 +183,7 @@ module Formtastic
       def extra_input_html_options
         {
           :multiple => multiple_by_association?,
-          :name => "#{object_name}[#{association_primary_key}]"
+          :name => "#{object_name}[#{association_primary_key}]#{'[]' if multiple?}"
         }
       end
       
@@ -202,7 +202,7 @@ module Formtastic
       def single?
         !multiple?
       end
-        
+
     end
   end
 end

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -315,7 +315,11 @@ describe 'select input' do
     it 'should have a multi-select select' do
       output_buffer.should have_tag('form li select[@multiple="multiple"]')
     end
-
+    
+    it 'should append [] to the name attribute for multiple select' do
+      output_buffer.should have_tag('form li select[@multiple="multiple"][@name="author[post_ids][]"]')
+    end
+    
     it 'should have a select option for each Post' do
       output_buffer.should have_tag('form li select option', :count => ::Post.all.size)
       ::Post.all.each do |post|


### PR DESCRIPTION
Multiple selects need to have [] appended to their name attributes in order to successfully submit multiple selections in array form
