### PR TITLE
Allow a radio field to have specific options set on each button

### DIFF
--- a/lib/formtastic/inputs/base/choices.rb
+++ b/lib/formtastic/inputs/base/choices.rb
@@ -45,7 +45,11 @@ module Formtastic
         end
 
         def choice_value(choice)
-          choice.is_a?(Array) ? choice.last : choice
+          choice.is_a?(Array) ? choice[1] : choice
+        end
+
+        def choice_options(choice)
+          ((choice.is_a?(Array) && choice.size > 2) ? choice.last : {}).merge(:id => choice_input_dom_id(choice))
         end
 
         def choice_html_safe_value(choice)

--- a/lib/formtastic/inputs/radio_input.rb
+++ b/lib/formtastic/inputs/radio_input.rb
@@ -137,7 +137,7 @@ module Formtastic
 
       def choice_html(choice)        
         template.content_tag(:label,
-          builder.radio_button(input_name, choice_value(choice), input_html_options.merge(:id => choice_input_dom_id(choice))) << 
+          builder.radio_button(input_name, choice_value(choice), input_html_options.merge(choice_options(choice))) << 
           choice_label(choice),
           label_html_options.merge(:for => choice_input_dom_id(choice))
         )

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -83,6 +83,15 @@ describe 'radio input' do
         output_buffer.should have_tag("form li fieldset ol li label input[@checked='checked']")
       end
 
+      it "should mark the input as disabled if options attached for disabling" do
+        concat(semantic_form_for(@new_post) do |builder|
+          concat(builder.input(:author, :as => :radio, :collection => [["Test", 'test'], ["Try", "try", {:disabled => true}]]))
+        end)
+
+        output_buffer.should_not have_tag("form li fieldset ol li label input[@value='test'][@disabled='disabled']")
+        output_buffer.should have_tag("form li fieldset ol li label input[@value='try'][@disabled='disabled']")
+      end
+
       it "should not contain invalid HTML attributes" do
 
         concat(semantic_form_for(@new_post) do |builder|


### PR DESCRIPTION
Allow a radio field to have specific options set on each button through the collection similar to options_for_select
