### PR TITLE
Don't strip '-' in choice_html_safe_value

### DIFF
--- a/lib/formtastic/inputs/base/choices.rb
+++ b/lib/formtastic/inputs/base/choices.rb
@@ -64,7 +64,7 @@ module Formtastic
         end
 
         def choice_html_safe_value(choice)
-          choice_value(choice).to_s.gsub(/\s/, '_').gsub(/\W/, '').downcase
+          choice_value(choice).to_s.gsub(/\s/, '_').gsub(/[^\w-]/, '').downcase
         end
 
         def choice_input_dom_id(choice)

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -296,7 +296,7 @@ module CustomMacros
               output_buffer.should have_tag("form li fieldset ol li label[@for='post_author_category_name_general']")
               output_buffer.should have_tag("form li fieldset ol li label[@for='post_author_category_name_design']")
               output_buffer.should have_tag("form li fieldset ol li label[@for='post_author_category_name_development']")
-              output_buffer.should have_tag("form li fieldset ol li label[@for='post_author_category_name_quasiserious_inventions']")
+              output_buffer.should have_tag("form li fieldset ol li label[@for='post_author_category_name_quasi-serious_inventions']")
             end
           end
         end


### PR DESCRIPTION
When using a radio with a collection of e.g. [1, 0, -1], the ids of the
generated input tags are the same for 1 and -1. By not stripping '-', we
get unique ids in this case.
