### PR TITLE
Boolean fields should not use global requied default. Fixes #580

### DIFF
--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -2,7 +2,7 @@ module Formtastic
   module Inputs
     module Base
       module Validations
-        
+
         class IndeterminableMinimumAttributeError < ArgumentError
           def message
             [
@@ -20,9 +20,9 @@ module Formtastic
             ].join("\n")
           end
         end
-        
+
         def validations
-          @validations ||= if object && object.class.respond_to?(:validators_on) 
+          @validations ||= if object && object.class.respond_to?(:validators_on)
             object.class.validators_on(attributized_method_name).select do |validator|
               validator_relevant?(validator)
             end
@@ -30,11 +30,11 @@ module Formtastic
             []
           end
         end
-        
+
         def validator_relevant?(validator)
           return true unless validator.options.key?(:if) || validator.options.key?(:unless)
           conditional = validator.options.key?(:if) ? validator.options[:if] : validator.options[:unless]
-          
+
           result = if conditional.respond_to?(:call)
             conditional.call(object)
           elsif conditional.is_a?(::Symbol) && object.respond_to?(conditional)
@@ -42,13 +42,13 @@ module Formtastic
           else
             conditional
           end
-          
+
           result = validator.options.key?(:unless) ? !result : !!result
           not_required_through_negated_validation! if !result && [:presence, :inclusion, :length].include?(validator.kind)
 
           result
         end
-        
+
         def validation_limit
           validation = validations? && validations.find do |validation|
             validation.kind == :length
@@ -59,17 +59,17 @@ module Formtastic
             nil
           end
         end
-        
+
         # Prefer :greater_than_or_equal_to over :greater_than, for no particular reason.
         def validation_min
           validation = validations? && validations.find do |validation|
             validation.kind == :numericality
           end
-          
-          if validation 
+
+          if validation
             # We can't determine an appropriate value for :greater_than with a float/decimal column
             raise IndeterminableMinimumAttributeError if validation.options[:greater_than] && column? && [:float, :decimal].include?(column.type)
-            
+
             return validation.options[:greater_than_or_equal_to] if validation.options[:greater_than_or_equal_to]
             return (validation.options[:greater_than] + 1)       if validation.options[:greater_than]
           end
@@ -83,12 +83,12 @@ module Formtastic
           if validation
             # We can't determine an appropriate value for :greater_than with a float/decimal column
             raise IndeterminableMaximumAttributeError if validation.options[:less_than] && column? && [:float, :decimal].include?(column.type)
-            
+
             return validation.options[:less_than_or_equal_to] if validation.options[:less_than_or_equal_to]
             return (validation.options[:less_than] - 1)       if validation.options[:less_than]
           end
         end
-        
+
         def validation_step
           validation = validations? && validations.find do |validation|
             validation.kind == :numericality
@@ -110,33 +110,37 @@ module Formtastic
             false
           end
         end
-        
+
         def validations?
           !validations.empty?
         end
-        
+
         def required?
           return false if options[:required] == false
           return true if options[:required] == true
           return false if not_required_through_negated_validation?
           if validations?
-            validations.select { |validator| 
+            validations.select { |validator|
               [:presence, :inclusion, :length].include?(validator.kind) &&
               validator.options[:allow_blank] != true
             }.any?
           else
-            return !!builder.all_fields_required_by_default
+            return responds_to_global_required? && !!builder.all_fields_required_by_default
           end
         end
-        
+
         def not_required_through_negated_validation?
           @not_required_through_negated_validation
         end
-        
+
         def not_required_through_negated_validation!
           @not_required_through_negated_validation = true
         end
-        
+
+        def responds_to_global_required?
+          true
+        end
+
         def optional?
           !required?
         end
@@ -150,14 +154,13 @@ module Formtastic
         def column_limit
           column.limit if column? && column.respond_to?(:limit)
         end
-        
+
         def limit
           validation_limit || column_limit
         end
-        
+
       end
     end
   end
 end
-        
-        
+

--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -31,53 +31,57 @@ module Formtastic
     # @see Formtastic::Helpers::InputsHelper#input InputsHelper#input for full documetation of all possible options.
     class BooleanInput
       include Base
-      
+
       def to_html
         input_wrapping do
-          hidden_field_html << 
+          hidden_field_html <<
           label_with_nested_checkbox
         end
       end
-      
+
       def hidden_field_html
         template.hidden_field_tag(input_html_options[:name], unchecked_value, :id => nil, :disabled => input_html_options[:disabled] )
       end
-            
+
       def label_with_nested_checkbox
         builder.label(
           method,
-          label_text_with_embedded_checkbox, 
+          label_text_with_embedded_checkbox,
           label_html_options
         )
       end
-      
+
       def label_html_options
         input_html_options.merge(
           :id => nil,
           :for => input_html_options[:id]
         )
       end
-      
+
       def label_text_with_embedded_checkbox
         label_text << " " << check_box_html
       end
-      
+
       def check_box_html
         template.check_box_tag("#{object_name}[#{method}]", checked_value, checked?, input_html_options)
       end
-      
+
       def unchecked_value
         options[:unchecked_value] || '0'
       end
-      
+
       def checked_value
         options[:checked_value] || '1'
       end
-      
+
+      def responds_to_global_required?
+        false
+      end
+
       def input_html_options
         {:name => "#{object_name}[#{method}]"}.merge(super)
       end
-      
+
       def checked?
         object && ActionView::Helpers::InstanceTag.check_box_checked?(object.send(method), checked_value)
       end

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -27,7 +27,7 @@ describe 'boolean input' do
     output_buffer.should have_tag('form li input[@type="hidden"]', :count => 1)
     output_buffer.should_not have_tag('form li label input[@type="hidden"]', :count => 1) # invalid HTML5
   end
-  
+
   it 'should generate a checkbox input' do
     output_buffer.should have_tag('form li label input')
     output_buffer.should have_tag('form li label input#post_allow_comments')
@@ -35,13 +35,13 @@ describe 'boolean input' do
     output_buffer.should have_tag('form li label input[@name="post[allow_comments]"]')
     output_buffer.should have_tag('form li label input[@type="checkbox"][@value="1"]')
   end
-  
+
   it 'should generate a checked input if object.method returns true' do
     output_buffer.should have_tag('form li label input[@checked="checked"]')
     output_buffer.should have_tag('form li input[@name="post[allow_comments]"]', :count => 2)
     output_buffer.should have_tag('form li input#post_allow_comments', :count => 1)
   end
-  
+
   it 'should generate a checked input if :input_html is passed :checked => checked' do
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:answer_comments, :as => :boolean, :input_html => {:checked => 'checked'}))
@@ -53,20 +53,20 @@ describe 'boolean input' do
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:answer_comments, :as => :boolean, :input_html => { :name => "foo" }))
     end)
-    
+
     output_buffer.should have_tag('form li input[@type="checkbox"][@name="foo"]', :count => 1)
     output_buffer.should have_tag('form li input[@type="hidden"][@name="foo"]', :count => 1)
   end
-  
+
   it 'should name the hidden input with the :name html_option' do
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:answer_comments, :as => :boolean, :input_html => { :name => "foo" }))
     end)
-    
+
     output_buffer.should have_tag('form li input[@type="checkbox"][@name="foo"]', :count => 1)
     output_buffer.should have_tag('form li input[@type="hidden"][@name="foo"]', :count => 1)
   end
-  
+
   it "should generate a disabled input and hidden input if :input_html is passed :disabled => 'disabled' " do
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:allow_comments, :as => :boolean, :input_html => {:disabled => 'disabled'}))
@@ -74,7 +74,7 @@ describe 'boolean input' do
     output_buffer.should have_tag('form li label input[@disabled="disabled"]', :count => 1)
     output_buffer.should have_tag('form li input[@type="hidden"][@disabled="disabled"]', :count => 1)
   end
-  
+
   it 'should generate an input[id] with matching label[for] when id passed in :input_html' do
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:allow_comments, :as => :boolean, :input_html => {:id => 'custom_id'}))
@@ -91,24 +91,24 @@ describe 'boolean input' do
     output_buffer.should have_tag('form li input[@type="hidden"][@value="unchecked"]')
     output_buffer.should_not have_tag('form li label input[@type="hidden"]') # invalid HTML5
   end
-  
+
   it 'should generate a checked input if object.method returns checked value' do
     @new_post.stub!(:allow_comments).and_return('yes')
-  
+
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:allow_comments, :as => :boolean, :checked_value => 'yes', :unchecked_value => 'no'))
     end)
-  
+
     output_buffer.should have_tag('form li label input[@type="checkbox"][@value="yes"][@checked="checked"]')
   end
-  
+
   it 'should not generate a checked input if object.method returns unchecked value' do
     @new_post.stub!(:allow_comments).and_return('no')
-  
+
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:allow_comments, :as => :boolean, :checked_value => 'yes', :unchecked_value => 'no'))
     end)
-  
+
     output_buffer.should have_tag('form li label input[@type="checkbox"][@value="yes"]:not([@checked])')
   end
 
@@ -145,7 +145,7 @@ describe 'boolean input' do
     output_buffer.should have_tag('form li label input[@type="checkbox"]')
     output_buffer.should have_tag('form li label input[@name="project[allow_comments]"]')
   end
-  
+
   context "when required" do
     it "should add the required attribute to the input's html options" do
       concat(semantic_form_for(@new_post) do |builder|
@@ -153,8 +153,15 @@ describe 'boolean input' do
       end)
       output_buffer.should have_tag("input[@required]")
     end
+
+    it "should not add the required attribute to the boolean fields input's html options" do
+      concat(semantic_form_for(@new_post) do |builder|
+        concat(builder.input(:title, :as => :boolean))
+      end)
+      output_buffer.should_not have_tag("input[@required]")
+    end
   end
-  
+
   describe "when namespace is provided" do
 
     before do


### PR DESCRIPTION
I reforked from master. Finally got rid of unnecessary merge commits. 

Boolean fields do not add requried true even when global all_fields_required_by_default is set to true.
