### PR TITLE
Switch to gemspec generated by bundler.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,9 @@ require 'rake'
 require 'rake/rdoctask'
 require 'rspec/core/rake_task'
 require 'tasks/verify_rcov'
+require 'bundler'
+
+Bundler::GemHelper.install_tasks
 
 desc 'Default: run unit specs.'
 task :default => :spec_and_verify_coverage

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -1,18 +1,23 @@
 # encoding: utf-8
+$:.push File.expand_path("../lib", __FILE__)
+require "formtastic/version"
 
 Gem::Specification.new do |s|
-  s.name = %q{formtastic}
-  s.version = "2.0.0.pre"
-  s.date = %q{2011-01-07}
-
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Justin French"]
+  s.name        = %q{formtastic}
+  s.version     = Formtastic::VERSION
+  s.date        = %q{2011-01-07}
+  s.platform    = Gem::Platform::RUBY
+  s.authors     = [%q{Justin French}]
+  s.email       = [%q{justin@indent.com.au}]
+  s.homepage    = %q{http://github.com/justinfrench/formtastic/tree/master}
+  s.summary     = %q{A Rails form builder plugin/gem with semantically rich and accessible markup}
   s.description = %q{A Rails form builder plugin/gem with semantically rich and accessible markup}
-  s.summary = %q{A Rails form builder plugin/gem with semantically rich and accessible markup}
-  s.email = %q{justin@indent.com.au}
-  s.extra_rdoc_files = ["README.textile"]
-  s.files = Dir.glob("{lib,spec}/**/*") + %w(MIT-LICENSE README.textile)
-  s.homepage = %q{http://github.com/justinfrench/formtastic/tree/master}
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.require_paths = ["lib"]
+
   s.post_install_message = %q{
   ========================================================================
   Thanks for installing Formtastic!
@@ -32,7 +37,9 @@ Gem::Specification.new do |s|
   ========================================================================
   }
   s.rdoc_options = ["--charset=UTF-8"]
-  s.require_paths = ["lib"]
+  s.extra_rdoc_files = ["README.textile"]
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.rubygems_version = %q{1.3.6}
 
   s.add_dependency(%q<rails>, ["~> 3.0"])
@@ -44,5 +51,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<yard>, ["~> 0.6"])
   s.add_development_dependency(%q<rcov>, ["~> 0.9.9"])
   s.add_development_dependency(%q<colored>)
-
 end

--- a/lib/formtastic/version.rb
+++ b/lib/formtastic/version.rb
@@ -1,0 +1,3 @@
+module Formtastic
+  VERSION = "2.0.0.pre"
+end


### PR DESCRIPTION
In #535 #548, @sobrinho says "switch to gemspec generated by bundler". This patch does it.
