### PR TITLE
Checkboxes w/collection not being checked

### DIFF
--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -358,6 +358,23 @@ describe 'check_boxes input' do
       end
     end
   end
+  
+  describe 'when :collection is provided' do
+    before do
+      @output_buffer = ''
+      mock_everything
+      @fred.stub(:genres) { ['ficton', 'biography'] }
+      
+      concat(semantic_form_for(@fred) do |builder|
+        concat(builder.input(:genres, :as => :check_boxes, :collection => [['Fiction', 'fiction'], ['Non-fiction', 'non_fiction'], ['Biography', 'biography']]))
+      end)
+    end
+    
+    it 'should check the correct checkboxes' do
+      output_buffer.should have_tag("form li fieldset ol li label input[@value='fiction'][@checked='checked']")
+      output_buffer.should have_tag("form li fieldset ol li label input[@value='biography'][@checked='checked']")
+    end
+  end
 
   describe "when namespace is provided" do
 


### PR DESCRIPTION
The problem occur with the following pseudo-code:

<pre>
@book = Book.first
=> #&lt;Book ...&gt;

@book.genres
=> ['fiction', 'biography']
</pre>


And generating the form like this:

<pre>
semantic_form_for @book do |f|
  f.input :genres, :as => :check_boxes, :collection => [['Fiction etc.', 'fiction'], ['Biography', 'biography'], ['Non-fiction', 'non_fiction']]
end
</pre>


Attached is a failing spec.

Tested on master and Rails 3.0.9 and Rails 3.0.7
