### PR TITLE
Fix positioning bug: labels inside a check box group or radio group are not visible

### DIFF
--- a/app/assets/stylesheets/formtastic.css
+++ b/app/assets/stylesheets/formtastic.css
@@ -128,6 +128,10 @@ This stylesheet forms part of the Formtastic Rails Plugin
   position:absolute;
 }
 
+.formtastic .choice .label {
+  position:relative;
+}
+
 /* NESTED FIELDSETS AND LEGENDS (radio, check boxes and date/time inputs use nested fieldsets)
 --------------------------------------------------------------------------------------------------*/
 .formtastic .choices {


### PR DESCRIPTION
Verified in FF5, Opera v11.50, Chrome v12, IE7, IE8, and IE9
