### PR TITLE
Change the way 'perform_browser_validations' option is used.

### DIFF
--- a/lib/formtastic/helpers/form_helper.rb
+++ b/lib/formtastic/helpers/form_helper.rb
@@ -143,7 +143,7 @@ module Formtastic
         options = args.extract_options!
         options[:builder] ||= @@builder
         options[:html] ||= {}
-        options[:html][:novalidate] = builder.perform_browser_validations unless options[:html].key?(:novalidate)
+        options[:html][:novalidate] = !builder.perform_browser_validations unless options[:html].key?(:novalidate)
         @@builder.custom_namespace = options[:namespace].to_s
 
         singularizer = defined?(ActiveModel::Naming.singular) ? ActiveModel::Naming.method(:singular) : ActionController::RecordIdentifier.method(:singular_class_name)

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -28,7 +28,7 @@ describe 'FormHelper' do
       with_config :perform_browser_validations, true do
         concat(semantic_form_for(@new_post, :url => '/hello') do |builder|
         end)
-        output_buffer.should have_tag("form[@novalidate]")
+        output_buffer.should_not have_tag("form[@novalidate]")
       end
     end
     
@@ -36,7 +36,7 @@ describe 'FormHelper' do
       with_config :perform_browser_validations, false do
         concat(semantic_form_for(@new_post, :url => '/hello') do |builder|
         end)
-        output_buffer.should_not have_tag("form[@novalidate]")
+        output_buffer.should have_tag("form[@novalidate]")
       end
     end
 


### PR DESCRIPTION
'novalidate' attribute should be added when this option is set to 'false'
instead of 'true'.

Related to #626.
