### PR TITLE
'step' attribute should default to "any".  

### DIFF
--- a/lib/formtastic/inputs/number_input.rb
+++ b/lib/formtastic/inputs/number_input.rb
@@ -96,7 +96,7 @@ module Formtastic
         return options[:step] if options.key?(:step)
         return validation_step if validation_step
         return 1 if validation_integer_only?
-        1
+        "any"
       end
       
       def min_option

--- a/spec/inputs/number_input_spec.rb
+++ b/spec/inputs/number_input_spec.rb
@@ -756,11 +756,11 @@ describe 'number input' do
       ])
     end
     
-    it "should default step to 1" do
+    it "should default step to 'any'" do
       concat(semantic_form_for(@new_post) do |builder|
         builder.input(:title, :as => :number)
       end)
-      output_buffer.should have_tag('input[@step="1"]')
+      output_buffer.should have_tag('input[@step="any"]')
     end
     
     it "should let input_html set :step" do


### PR DESCRIPTION
Right now the _step_ attribute for `number_input` defaults to '1' when cannot be inferred from validations and is not either supplied in the options.

It is ok for integer values, but when you have a float field in the database, an `input type="number"` is also rendered with `step="1"` and the browser doesn't submit the form when you enter a non-integer value. I think in this case it should use `step="any"`

See http://www.w3.org/TR/html-markup/input.number.html

This patch makes the _step_ attribute defaults to `"any"` instead of `"1"`.
