### PR TITLE
add failing spec for 677 select generates incorrect name when passed nil (only fails prior to 3.0.10)

### DIFF
--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -75,6 +75,16 @@ describe 'select input' do
         end
       end
     end
+    
+    describe 'using a nil name' do
+      before do
+        concat(semantic_form_for(@new_post) do |builder|
+          concat(builder.input(:title, :as => :select, :collection => [], :input_html => {:name => nil}))
+        end)
+      end
+
+      it_should_have_select_with_name("post[title]")
+    end
   end
 
   describe 'for boolean columns' do

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -86,6 +86,12 @@ module CustomMacros
       end
     end
 
+    def it_should_have_select_with_name(name)
+      it "should have an input named #{name}" do
+        output_buffer.should have_tag("form li select[@name=\"#{name}\"]")
+      end
+    end
+
     def it_should_have_textarea_with_name(name)
       it "should have an input named #{name}" do
         output_buffer.should have_tag("form li textarea[@name=\"#{name}\"]")


### PR DESCRIPTION
I'll be solving this myself by updating to rails 3.0.10 or higher. But I figured you might want the spec to protect against this creeping back in at a later date.
