### PR TITLE
empty-string Errors are not displayed

### DIFF
--- a/lib/formtastic/inputs/base/errors.rb
+++ b/lib/formtastic/inputs/base/errors.rb
@@ -38,6 +38,11 @@ module Formtastic
           errors = []
           if object && object.respond_to?(:errors)
             error_keys.each do |key| 
+              # --- Joel was here! ---
+              unless object.errors[key].blank?
+                object.errors[key].delete_if {|str| str.empty?}
+              end
+              # --------------------
               errors << object.errors[key] unless object.errors[key].blank?
             end
           end


### PR DESCRIPTION
Empty string error messages will not be displayed.  If we want to prevent some message from being sent by Mongoid or ActiveModel, we can just override the value to be "".
