### PR TITLE
Extract method field_set_legend.

### DIFF
--- a/lib/formtastic/helpers/fieldset_wrapper.rb
+++ b/lib/formtastic/helpers/fieldset_wrapper.rb
@@ -25,10 +25,6 @@ module Formtastic
         contents = args.last.is_a?(::Hash) ? '' : args.pop.flatten
         html_options = args.extract_options!
 
-        legend  = (html_options[:name] || '').to_s
-        legend %= parent_child_index(html_options[:parent]) if html_options[:parent]
-        legend  = template.content_tag(:legend, template.content_tag(:span, Formtastic::Util.html_safe(legend))) unless legend.blank?
-
         if block_given?
           contents = if template.respond_to?(:is_haml?) && template.is_haml?
             template.capture_haml(&block)
@@ -39,12 +35,20 @@ module Formtastic
 
         # Ruby 1.9: String#to_s behavior changed, need to make an explicit join.
         contents = contents.join if contents.respond_to?(:join)
+
+        legend = field_set_legend(html_options)
         fieldset = template.content_tag(:fieldset,
           Formtastic::Util.html_safe(legend) << template.content_tag(:ol, Formtastic::Util.html_safe(contents)),
           html_options.except(:builder, :parent, :name)
         )
 
         fieldset
+      end
+
+      def field_set_legend(html_options)
+        legend  = (html_options[:name] || '').to_s
+        legend %= parent_child_index(html_options[:parent]) if html_options[:parent]
+        legend  = template.content_tag(:legend, template.content_tag(:span, Formtastic::Util.html_safe(legend))) unless legend.blank?
       end
 
       # Gets the nested_child_index value from the parent builder. It returns a hash with each


### PR DESCRIPTION
Extracted from field_set_and_list_wrapping.

This lets us override how the legend is constructed
without affecting the rest of the fieldset. Also
makes field_set_and_list_wrapping a little more concise.
