### PR TITLE
never render fantom hidden input (should close #697)

### DIFF
--- a/lib/formtastic/inputs/check_boxes_input.rb
+++ b/lib/formtastic/inputs/check_boxes_input.rb
@@ -109,9 +109,7 @@ module Formtastic
       end
 
       def hidden_field_for_all
-        show_fantom = options[:hidden_fields]
-        show_fantom = true if show_fantom.nil?
-        unless show_fantom
+        unless hidden_collection?
           ""
         else
           options = {}
@@ -122,7 +120,13 @@ module Formtastic
       end
 
       def hidden_fields?
-        options[:hidden_fields]
+        render_hidden = options[:hidden_fields]
+        return false if render_hidden == :never
+        render_hidden
+      end
+
+      def hidden_collection?
+        options[:hidden_fields] != :never
       end
 
       def check_box_with_hidden_input(choice)

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -186,8 +186,23 @@ describe 'check_boxes input' do
         output_buffer.should_not have_tag("form li fieldset ol li label input[@type='hidden'][@value='']", :count => ::Post.all.length)
       end
 
+      it 'should generate collection hidden input' do
+        output_buffer.should have_tag("form input[@type='hidden'][@name='author[post_ids][]']", :count => 1)
+      end
+    end
+
+    describe 'when :hidden_fields is set to :never' do
+      before do
+        @output_buffer = ''
+        mock_everything
+
+        concat(semantic_form_for(@fred) do |builder|
+          concat(builder.input(:posts, :as => :check_boxes, :value_as_class => true, :hidden_fields => :never))
+        end)
+      end
+
       it 'should not generate any hidden inputs' do
-        output_buffer.should_not have_tag("form li fieldset input[@type='hidden']")
+        output_buffer.should_not have_tag("form li input[@type='hidden']")
       end
     end
 


### PR DESCRIPTION
See #697.

I did not use `hidden_fields?` as I it doesn't work exactly as I expect.
First of all, "?" method should return boolean, but it just returns the value from `options` which often is `nil`.

Converting it to `!!options[:hidden_fields]` will do the job but it won't be correct as in this case:
- `:hidden_fields => false` will return `false`
- `:hidden_fields => true` will return `true`
- `:hidden_fields => nil` will return `false` (when it is `nil` it should probably be `true` - render hidden by default).
