### PR TITLE
Update commit_button documentation

### DIFF
--- a/lib/formtastic/helpers/buttons_helper.rb
+++ b/lib/formtastic/helpers/buttons_helper.rb
@@ -22,7 +22,7 @@ module Formtastic
     #       ...
     #       <fieldset class="buttons">
     #         <ol>
-    #           <li class="commit">
+    #           <li class="commit button">
     #             <input type="submit" name="commit" value="Create Post" class="create">
     #           </li>
     #         </ol>
@@ -76,9 +76,9 @@ module Formtastic
       #
       #     # Output:
       #     <form ...>
-      #       <fieldset class="inputs">
+      #       <fieldset class="buttons">
       #         <ol>
-      #           <li class="commit">
+      #           <li class="commit button">
       #             <input type="submit" ...>
       #           </li>
       #         </ol>
@@ -203,7 +203,11 @@ module Formtastic
       #   <form ...>
       #     ...
       #     <fieldset class="buttons">
-      #       <input name="commit" type="submit" value="Create Post" class="create">
+      #       <ol>
+      #         <li class="commit button">
+      #           <input name="commit" type="submit" value="Create Post" class="create">
+      #         </li>
+      #       </ol>
       #     </fieldset>
       #   </form>
       #


### PR DESCRIPTION
When `button` was added to the array in `Formtastic::Helpers::ButtonHelpers#commit_button_wrapper_html_css` the documentation was never updated to reflect the changes. I changed the output html to include the new class.

Might I ask why button was added? We reuse a button class for all buttons, even those that are not in a form and we don't always wrap li's around it. I monkey patched it in the formtastic initializer, would this be the preferred method of overriding this behavior?
