### PR TITLE
Address syntax errors when running specs under 1.9.2-p290

### DIFF
--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -192,7 +192,7 @@ describe 'boolean input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :boolean))
         end)
       end)

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -400,7 +400,7 @@ describe 'check_boxes input' do
       mock_everything
 
       concat(semantic_form_for(@fred) do |builder|
-        concat(builder.fields_for @fred.posts.first, :index => 3 do |author|
+        concat(builder.fields_for(@fred.posts.first, :index => 3) do |author|
           concat(author.input(:authors, :as => :check_boxes))
         end)
       end)

--- a/spec/inputs/date_input_spec.rb
+++ b/spec/inputs/date_input_spec.rb
@@ -78,7 +78,7 @@ describe 'date input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:created_at, :as => :date))
         end)
       end)

--- a/spec/inputs/datetime_input_spec.rb
+++ b/spec/inputs/datetime_input_spec.rb
@@ -83,7 +83,7 @@ describe 'datetime input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:created_at, :as => :datetime))
         end)
       end)

--- a/spec/inputs/email_input_spec.rb
+++ b/spec/inputs/email_input_spec.rb
@@ -49,7 +49,7 @@ describe 'email input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :email))
         end)
       end)

--- a/spec/inputs/file_input_spec.rb
+++ b/spec/inputs/file_input_spec.rb
@@ -53,7 +53,7 @@ describe 'file input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :file))
         end)
       end)

--- a/spec/inputs/hidden_input_spec.rb
+++ b/spec/inputs/hidden_input_spec.rb
@@ -105,7 +105,7 @@ describe 'hidden input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :hidden))
         end)
       end)

--- a/spec/inputs/number_input_spec.rb
+++ b/spec/inputs/number_input_spec.rb
@@ -73,7 +73,7 @@ describe 'number input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :number))
         end)
       end)

--- a/spec/inputs/password_input_spec.rb
+++ b/spec/inputs/password_input_spec.rb
@@ -64,7 +64,7 @@ describe 'password input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :password))
         end)
       end)

--- a/spec/inputs/phone_input_spec.rb
+++ b/spec/inputs/phone_input_spec.rb
@@ -49,7 +49,7 @@ describe 'phone input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :phone))
         end)
       end)

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -241,7 +241,7 @@ describe 'radio input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :radio))
         end)
       end)

--- a/spec/inputs/range_input_spec.rb
+++ b/spec/inputs/range_input_spec.rb
@@ -49,7 +49,7 @@ describe 'range input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :range))
         end)
       end)

--- a/spec/inputs/search_input_spec.rb
+++ b/spec/inputs/search_input_spec.rb
@@ -49,7 +49,7 @@ describe 'search input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :search))
         end)
       end)

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -568,7 +568,7 @@ describe 'select input' do
       mock_everything
   
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :select))
         end)
       end)

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -131,7 +131,7 @@ describe 'string input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :string))
         end)
       end)

--- a/spec/inputs/text_input_spec.rb
+++ b/spec/inputs/text_input_spec.rb
@@ -88,7 +88,7 @@ describe 'text input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :text))
         end)
       end)

--- a/spec/inputs/time_input_spec.rb
+++ b/spec/inputs/time_input_spec.rb
@@ -202,7 +202,7 @@ describe 'time input' do
 
     before do
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:created_at, :as => :time))
         end)
       end)

--- a/spec/inputs/time_zone_input_spec.rb
+++ b/spec/inputs/time_zone_input_spec.rb
@@ -62,7 +62,7 @@ describe 'time_zone input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :time_zone))
         end)
       end)

--- a/spec/inputs/url_input_spec.rb
+++ b/spec/inputs/url_input_spec.rb
@@ -49,7 +49,7 @@ describe 'url input' do
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
-        concat(builder.fields_for :author, :index => 3 do |author|
+        concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :url))
         end)
       end)


### PR DESCRIPTION
The syntax introduced in 253dc6d559b610f04fab1bc43209d6caa0603d30, eg.

  concat(builder.fields_for :author, :index => 3 do |author|

was producing these errors:

  syntax error, unexpected keyword_do_block, expecting ')' (SyntaxError)
