### PR TITLE
Bring time input behavior in line with time_select when inputs are empty

### DIFF
--- a/lib/formtastic/inputs/time_input.rb
+++ b/lib/formtastic/inputs/time_input.rb
@@ -15,12 +15,8 @@ module Formtastic
         time_fragments
       end
       
-      def value_or_default_value
-        value ? value : Time.current
-      end
-      
       def fragment_value(fragment)
-        value_or_default_value.send(fragment)
+        value ? value.send(fragment) : ""
       end
       
       def hidden_fragments

--- a/spec/inputs/time_input_spec.rb
+++ b/spec/inputs/time_input_spec.rb
@@ -60,6 +60,33 @@ describe 'time input' do
 
     end
 
+    describe "with :ignore_date => false and no initial Time" do
+      before do
+        @new_post.stub(:publish_at)
+        concat(semantic_form_for(@new_post) do |builder|
+          concat(builder.input(:publish_at, :as => :time, :ignore_date => false))
+        end)
+      end
+
+      it 'should have a hidden input for day, month and year' do
+        output_buffer.should have_tag('input#post_publish_at_1i')
+        output_buffer.should have_tag('input#post_publish_at_2i')
+        output_buffer.should have_tag('input#post_publish_at_3i')
+      end
+
+      it 'should not have values in hidden inputs for day, month and year' do
+        output_buffer.should have_tag('input#post_publish_at_1i[@value=""]')
+        output_buffer.should have_tag('input#post_publish_at_2i[@value=""]')
+        output_buffer.should have_tag('input#post_publish_at_3i[@value=""]')
+      end
+
+      it 'should have an select for hour and minute' do
+        output_buffer.should have_tag('select#post_publish_at_4i')
+        output_buffer.should have_tag('select#post_publish_at_5i')
+      end
+
+    end
+
     describe "without seconds" do
       before do
         concat(semantic_form_for(@new_post) do |builder|


### PR DESCRIPTION
Before this change, it wasn't possible to create an input of type 'time'
that didn't default to the current date. This made it impossible to
differentiate between a form submission wherein the user hadn't picked a
date, and one in which they'd picked midnight UTC.
