### PR TITLE
Fix for #740

### DIFF
--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -54,18 +54,23 @@ module Formtastic
 
         def collection_from_association
           if reflection
-            raise PolymorphicInputWithoutCollectionError.new("A collection must be supplied for #{method} input. Collections cannot be guessed for polymorphic associations.") if reflection.options && reflection.options[:polymorphic] == true
+            if reflection.respond_to?(:options)
+              raise PolymorphicInputWithoutCollectionError.new(
+                        "A collection must be supplied for #{method} input. Collections cannot be guessed for polymorphic associations."
+                    ) if reflection.options[:polymorphic] == true
+            end
 
             find_options_from_options = options[:find_options] || {}
             conditions_from_options = find_options_from_options[:conditions] || {}
-            conditions_from_reflection = reflection.options && reflection.options[:conditions] || {}
+            conditions_from_reflection = (reflection.respond_to?(:options) && reflection.options[:conditions]) || {}
             conditions_from_reflection = conditions_from_reflection.call if conditions_from_reflection.is_a?(Proc)
 
+            scope_conditions = conditions_from_reflection.empty? ? nil : {:conditions => conditions_from_reflection}
             if conditions_from_options.any?
-              reflection.klass.scoped(:conditions => conditions_from_reflection).where(conditions_from_options)
+              reflection.klass.scoped(scope_conditions).where(conditions_from_options)
             else
               find_options_from_options.merge!(:include => group_by) if self.respond_to?(:group_by) && group_by
-              reflection.klass.scoped(:conditions => conditions_from_reflection).where(find_options_from_options)
+              reflection.klass.scoped(scope_conditions).where(find_options_from_options)
             end
           end
         end


### PR DESCRIPTION
Pull request 545 tried to fix #740, but mocked the mongoid reviewer in a way that didn't accurately reflect how Mongoid really behaves (it doesn't return `nil` for `reflection[:options]`, it throws a `NoMethodError`).  In addition, it masked a successive problem where a call to `.scoped(:conditions => nil)` for a model would always return empty results.

I've got a test in for the first part, but I have to admit to being a little stumped how I'd mock `scoped` properly to show I've dealt with the second.  All specs still pass but really a spec is required that shows that `scoped` shouldn't ever be called with `:conditions => nil`.  I'm afraid `spec_helper` rather got the better of me here in the hour I'd allocated to try and help out ;)
