### PR TITLE
State machine support 

### DIFF
--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -272,8 +272,7 @@ module Formtastic
       # default is a :string, a similar behaviour to Rails' scaffolding.
       def default_input_type(method, options = {}) #:nodoc:
         if @object
-          return :select  if reflection_for(method)
-
+          return :select  if reflection_for(method) || state_field_values(method)
           return :file    if is_file?(method, options)
         end
 
@@ -297,7 +296,7 @@ module Formtastic
             return :datetime
           end
 
-          # Try look for hints in options hash. Quite common senario: Enum keys stored as string in the database.
+          # Try look for hints in options hash. Quite common`` senario: Enum keys stored as string in the database.
           return :select    if column.type == :string && options.key?(:collection)
           # Try 3: Assume the input name will be the same as the column type (e.g. string_input).
           return column.type

--- a/lib/formtastic/helpers/reflection.rb
+++ b/lib/formtastic/helpers/reflection.rb
@@ -32,6 +32,18 @@ module Formtastic
           method.to_sym
         end
       end
+
+      def state_field_values(method)
+        if @object.class.respond_to?(:state_machines) && @object.class.state_machines[method]
+          machine = @object.class.state_machines[method]
+          return machine.states.keys
+        end
+        const_name = method.to_s.gsub("?", "").pluralize.upcase
+        if @object.class.const_defined?(const_name)
+          return @object.class.const_get(const_name)
+        end
+        nil
+      end
     end
   end
 end

--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -31,7 +31,7 @@ module Formtastic
         end
 
         def raw_collection
-          @raw_collection ||= (collection_from_options || collection_from_association || collection_for_boolean)
+          @raw_collection ||= (collection_from_options || collection_from_association || collection_for_state_field || collection_for_boolean)
         end
 
         def collection
@@ -48,6 +48,12 @@ module Formtastic
 
         def collection_from_options
           items = options[:collection]
+          items = items.to_a if items.is_a?(Hash)
+          items
+        end
+
+        def collection_for_state_field
+          items = state_field_values(method)
           items = items.to_a if items.is_a?(Hash)
           items
         end

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -488,6 +488,11 @@ describe 'Formtastic::FormBuilder#input' do
             end
           end
 
+          it "should detect :select field for state-fields" do
+            semantic_form_for(::Author.new) do |builder|
+              builder.send(:default_input_type, :gender).should == :select
+            end
+          end
         end
       end
 

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -87,6 +87,22 @@ describe 'select input' do
     end
   end
 
+  describe 'using state-fields with CONSTANT' do
+    before do
+      concat(semantic_form_for(@fred) do |builder|
+        concat(builder.input(:gender))
+      end)
+    end
+
+    it "should build select with options in constant" do
+      output_buffer.should have_tag('form li select')
+
+      ::Author::GENDERS.each do |gender|
+        output_buffer.should have_tag("option[@value='#{gender}']", /^#{gender}$/)
+      end
+    end
+  end
+
   describe 'for boolean columns' do
     describe 'default formtastic locale' do
       before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,7 +110,7 @@ module FormtasticSpecHelper
   class ::Author
     extend ActiveModel::Naming if defined?(ActiveModel::Naming)
     include ActiveModel::Conversion if defined?(ActiveModel::Conversion)
-
+    GENDERS = %W{Male Female}
     def to_label
     end
 
@@ -270,7 +270,7 @@ module FormtasticSpecHelper
     @freds_post.stub!(:persisted?).and_return(nil)
     @fred.stub!(:posts).and_return([@freds_post])
     @fred.stub!(:post_ids).and_return([@freds_post.id])
-
+    @fred.stub!(:gender).and_return("Male")
     ::Post.stub!(:scoped).and_return(::Post)
     ::Post.stub!(:human_attribute_name).and_return { |column_name| column_name.humanize }
     ::Post.stub!(:human_name).and_return('Post')


### PR DESCRIPTION
I made support for state_machine fields and fields with set of values for example

``` ruby
class User
  GENDERS = %w{male female}
  state_machine :state, :initial => :open do
    state :green
    state :yellow
    state :ready
  end
end
```

 fields `gender` and `state` will be rendered as select input
