### PR TITLE
Fix include_blank specs

### DIFF
--- a/spec/inputs/include_blank_spec.rb
+++ b/spec/inputs/include_blank_spec.rb
@@ -11,70 +11,65 @@ describe "*select: options[:include_blank]" do
 
     @new_post.stub!(:author_id).and_return(nil)
     @new_post.stub!(:publish_at).and_return(nil)
-
-    @select_input_types = {
-        :select => :author,
-        :datetime => :publish_at,
-        :date => :publish_at,
-        :time => :publish_at
-      }
   end
 
-  describe 'when :include_blank is not set' do
-    it 'blank value should be included if the default value specified in config is true' do
-      Formtastic::FormBuilder.include_blank_for_select_by_default = true
-      @select_input_types.each do |as, attribute|
-        concat(semantic_form_for(@new_post) do |builder|
-          concat(builder.input(attribute, :as => as))
-        end)
-        output_buffer.should have_tag("form li select option[@value='']", "")
+  SELECT_INPUT_TYPES = {
+      :select => :author,
+      :datetime => :publish_at,
+      :date => :publish_at,
+      :time => :publish_at
+    }
+
+  SELECT_INPUT_TYPES.each do |as, attribute|
+    describe "for #{as} input" do
+
+      describe 'when :include_blank is not set' do
+        it 'blank value should be included if the default value specified in config is true' do
+          Formtastic::FormBuilder.include_blank_for_select_by_default = true
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(attribute, :as => as))
+          end)
+          output_buffer.should have_tag("form li select option[@value='']", "")
+        end
+
+        it 'blank value should not be included if the default value specified in config is false' do
+          Formtastic::FormBuilder.include_blank_for_select_by_default = false
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(attribute, :as => as))
+          end)
+          output_buffer.should_not have_tag("form li select option[@value='']", "")
+        end
+
+        after do
+          Formtastic::FormBuilder.include_blank_for_select_by_default = true
+        end
       end
-    end
 
-    it 'blank value should not be included if the default value specified in config is false' do
-      Formtastic::FormBuilder.include_blank_for_select_by_default = false
-      @select_input_types.each do |as, attribute|
-        concat(semantic_form_for(@new_post) do |builder|
-          concat(builder.input(attribute, :as => as))
-        end)
-        output_buffer.should_not have_tag("form li select option[@value='']", "")
+      describe 'when :include_blank is set to false' do
+        it 'should not have a blank option' do
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(attribute, :as => as, :include_blank => false))
+          end)
+          output_buffer.should_not have_tag("form li select option[@value='']", "")
+        end
       end
-    end
 
-    after do
-      Formtastic::FormBuilder.include_blank_for_select_by_default = true
-    end
-  end
-
-  describe 'when :include_blank is set to false' do
-    it 'should not have a blank option' do
-      @select_input_types.each do |as, attribute|
-        concat(semantic_form_for(@new_post) do |builder|
-          concat(builder.input(attribute, :as => as, :include_blank => false))
-        end)
-        output_buffer.should_not have_tag("form li select option[@value='']", "")
+      describe 'when :include_blank is set to true' do
+        it 'should have a blank select option' do
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(attribute, :as => as, :include_blank => true))
+          end)
+          output_buffer.should have_tag("form li select option[@value='']", "")
+        end
       end
-    end
-  end
 
-  describe 'when :include_blank is set to true' do
-    it 'should have a blank select option' do
-      @select_input_types.each do |as, attribute|
-        concat(semantic_form_for(@new_post) do |builder|
-          concat(builder.input(attribute, :as => as, :include_blank => true))
-        end)
-        output_buffer.should have_tag("form li select option[@value='']", "")
-      end
-    end
-  end
-
-  describe 'when :include_blank is set to a string' do
-    it 'should have a select option with blank value but that string as text' do
-      @select_input_types.each do |as, attribute|
-        concat(semantic_form_for(@new_post) do |builder|
-          concat(builder.input(attribute, :as => as, :include_blank => 'string'))
-        end)
-        output_buffer.should have_tag("form li select option[@value='']", "string")
+      describe 'when :include_blank is set to a string' do
+        it 'should have a select option with blank value but that string as text' do
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(attribute, :as => as, :include_blank => 'string'))
+          end)
+          output_buffer.should have_tag("form li select option[@value='']", "string")
+        end
       end
     end
   end


### PR DESCRIPTION
[include_blank_spec.rb](https://github.com/justinfrench/formtastic/blob/master/spec/inputs/include_blank_spec.rb) doesn't test the different input types independently. Each spec is similar to

``` ruby
it 'should have a blank select option' do
  @select_input_types.each do |as, attribute|
    concat(semantic_form_for(@new_post) do |builder|
      concat(builder.input(attribute, :as => as, :include_blank => true))
    end)
    output_buffer.should have_tag("form li select option[@value='']", "")
  end
end
```

but because each input is appended to the output buffer, if the expectation passes on the first input type, it will pass for the rest (because the css selector will always match the item added on the first iteration).
