### PR TITLE
Froze rspec to ~> 2.6.0 for now

### DIFF
--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<actionpack>, ["~> 3.0"])
 
-  s.add_development_dependency(%q<rspec-rails>, ["~> 2.5"])
+  s.add_development_dependency(%q<rspec-rails>, ["~> 2.6.0"])
   s.add_development_dependency(%q<rspec_tag_matchers>, [">= 1.0.0"])
   s.add_development_dependency(%q<hpricot>, ["~> 0.8.3"])
   s.add_development_dependency(%q<BlueCloth>) # for YARD


### PR DESCRIPTION
Test suite doesn't currently run under 2.7
