### PR TITLE
Fix timeish legend label

### DIFF
--- a/lib/formtastic/inputs/base/timeish.rb
+++ b/lib/formtastic/inputs/base/timeish.rb
@@ -201,7 +201,7 @@ module Formtastic
         def fragments_label
           if render_label?
             template.content_tag(:legend, 
-              builder.label(method, label_text, :for => "#{input_html_options[:id]}_1i"), 
+              builder.label(method, label_text, :for => fragment_id(fragments.first)), 
               :class => "label"
             )
           else

--- a/spec/inputs/date_input_spec.rb
+++ b/spec/inputs/date_input_spec.rb
@@ -211,4 +211,17 @@ describe 'date input' do
     end
   end
 
+  describe "when order does not have year first" do
+    before do
+      output_buffer.replace ''
+      concat(semantic_form_for(@new_post) do |builder|
+        concat(builder.input(:publish_at, :as => :date, :order => [:day, :month, :year]))
+      end)
+    end
+
+    it 'should associate the legend label with the new first select' do
+      output_buffer.should have_tag('form li.date fieldset legend.label label[@for="post_publish_at_3i"]')
+    end
+  end
+
 end

--- a/spec/inputs/datetime_input_spec.rb
+++ b/spec/inputs/datetime_input_spec.rb
@@ -168,5 +168,18 @@ describe 'datetime input' do
       end
     end
   end
+
+  describe "when order does not have year first" do
+    before do
+      output_buffer.replace ''
+      concat(semantic_form_for(@new_post) do |builder|
+        concat(builder.input(:publish_at, :as => :datetime, :order => [:day, :month, :year]))
+      end)
+    end
+
+    it 'should associate the legend label with the new first select' do
+      output_buffer.should have_tag('form li.datetime fieldset legend.label label[@for="post_publish_at_3i"]')
+    end
+  end
   
 end

--- a/spec/inputs/time_input_spec.rb
+++ b/spec/inputs/time_input_spec.rb
@@ -58,6 +58,10 @@ describe 'time input' do
         output_buffer.should have_tag('select#post_publish_at_5i')
       end
 
+      it 'should associate the legend label with the hour select' do
+        output_buffer.should have_tag('form li.time fieldset legend.label label[@for="post_publish_at_4i"]')
+      end
+
     end
 
     describe "with :ignore_date => false and no initial Time" do
@@ -107,7 +111,7 @@ describe 'time input' do
       end
 
       it 'should associate the legend label with the first select' do
-        output_buffer.should have_tag('form li.time fieldset legend.label label[@for="post_publish_at_1i"]')
+        output_buffer.should have_tag('form li.time fieldset legend.label label[@for="post_publish_at_4i"]')
       end
 
       it 'should have an ordered list of two items inside the fieldset' do


### PR DESCRIPTION
The label element created in the timeish inputs' legend is always `<label for="..._1i">` (i.e. pointing to the year input), which is no good for time-only inputs or when other date orders are used (e.g when using d-m-y order, clicking on the label sets the focus to the third input in the list, which is disconcerting).
