### PR TITLE
Refactor collection label and value methods. Closes #732

### DIFF
--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -4,14 +4,26 @@ module Formtastic
       module Collections
 
         def label_method
-          label_and_value_method(raw_collection).first
+          @label_method ||= (label_method_from_options || label_and_value_method.first)
+        end
+
+        def label_method_from_options
+          options[:member_label]
         end
 
         def value_method
-          label_and_value_method(raw_collection).last
+          @value_method ||= (value_method_from_options || label_and_value_method.last)
         end
 
-        def label_and_value_method(_collection, grouped=false)
+        def value_method_from_options
+          options[:member_value]
+        end
+
+        def label_and_value_method
+          @label_and_value_method ||= label_and_value_method_from_collection(raw_collection)
+        end
+
+        def label_and_value_method_from_collection(_collection)
           sample = _collection.first || _collection.last
 
           case sample
@@ -24,8 +36,8 @@ module Formtastic
           end
 
           # Order of preference: user supplied method, class defaults, auto-detect
-          label = (grouped ? options[:grouped_label_method] : options[:member_label]) || label || builder.collection_label_methods.find { |m| sample.respond_to?(m) }
-          value = (grouped ? options[:grouped_value_method] : options[:member_value]) || value || builder.collection_value_methods.find { |m| sample.respond_to?(m) }
+          label ||= builder.collection_label_methods.find { |m| sample.respond_to?(m) }
+          value ||= builder.collection_value_methods.find { |m| sample.respond_to?(m) }
 
           [label, value]
         end

--- a/lib/formtastic/inputs/base/grouped_collections.rb
+++ b/lib/formtastic/inputs/base/grouped_collections.rb
@@ -20,7 +20,7 @@ module Formtastic
         end
       
         def group_label_method_from_grouped_collection
-          label_and_value_method(raw_grouped_collection, true).first
+          label_and_value_method_from_collection(raw_grouped_collection).first
         end
       
         def group_association


### PR DESCRIPTION
@justinfrench I wanted to check this before it goes in, because I've deleted a reference to the `grouped_value_method` option, which, unlike `grouped_label_method`, doesn't seem to have been deprecated (454dd44c00c512509ce6b9b09ad19e72e620af34). Removing it could theoretically break backwards compatibility, but it seems to be undocumented so I would expect that it's unlikely anyone is relying on it. Thoughts?
