### PR TITLE
Ensure associations is a hash before accessing it like a hash

### DIFF
--- a/lib/formtastic/helpers/reflection.rb
+++ b/lib/formtastic/helpers/reflection.rb
@@ -7,7 +7,10 @@ module Formtastic
       def reflection_for(method) #:nodoc:
         if @object.class.respond_to?(:reflect_on_association)
           @object.class.reflect_on_association(method) 
-        elsif @object.class.respond_to?(:associations) # MongoMapper uses the 'associations(method)' instead
+        
+        # MongoMapper uses the 'associations(method)' instead
+        # ReactiveResource does as well but its an array. Also make sure we are working with a hash
+        elsif @object.class.respond_to?(:associations) && @object.class.is_a?(Hash)
           @object.class.associations[method]
         end
       end


### PR DESCRIPTION
I am using reactive resource with ActiveResource. It enhances the model with an associations array. The current method for accessing the associations property assumes its a hash (if it exists at all). I added an extra check to make sure its a hash.
