### PR TITLE
Performance degradation in content_columns: respond_to instead of rescue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage
 coverage.data
 pkg
 *~
+*.swp
 *watchr.rb
 log/*
 .rvmrc

--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -351,7 +351,8 @@ module Formtastic
 
       # Collects content columns (non-relation columns) for the current form object class.
       def content_columns #:nodoc:
-        klass = model_name.constantize
+        # TODO: NameError is raised by Inflector.constantize. Consider checking if it exists instead.
+        begin klass = model_name.constantize; rescue NameError; return [] end
         return [] unless klass.respond_to?(:content_columns)
         klass.content_columns.collect { |c| c.name.to_sym }.compact
       end

--- a/spec/helpers/inputs_helper_spec.rb
+++ b/spec/helpers/inputs_helper_spec.rb
@@ -438,7 +438,7 @@ describe 'Formtastic::FormBuilder#inputs' do
   
       describe 'and no object is given' do
         it 'should render a form with a fieldset containing two list items' do
-          concat(semantic_form_for(:post, :url => 'http://test.host') do |builder|
+          concat(semantic_form_for(:project, :url => 'http://test.host') do |builder|
             concat(builder.inputs(:title, :body))
           end)
   
@@ -486,11 +486,11 @@ describe 'Formtastic::FormBuilder#inputs' do
   
       describe 'and no object is given' do
         it 'should render nested inputs' do
-          concat(semantic_form_for(:post, :url => 'http://test.host/') do |builder|
+          concat(semantic_form_for(:project, :url => 'http://test.host/') do |builder|
             concat(builder.inputs(:login, :for => @bob))
           end)
-          output_buffer.should have_tag("form fieldset.inputs #post_author_login")
-          output_buffer.should_not have_tag("form fieldset.inputs #post_login")
+          output_buffer.should have_tag("form fieldset.inputs #project_author_login")
+          output_buffer.should_not have_tag("form fieldset.inputs #project_login")
         end
       end
     end


### PR DESCRIPTION
`rescue` causes a slowdown for ORMs that don't have `content_columns`

See https://gist.github.com/2bea805664bfb6491d1d#gistcomment-73931

`rescue`-ing from everything is pretty weird thing to.

(Should probably consider not using it at all here).
