### PR TITLE
fixing out of date reference to the official rails country_select plugin...

### DIFF
--- a/lib/formtastic/inputs/country_input.rb
+++ b/lib/formtastic/inputs/country_input.rb
@@ -4,7 +4,8 @@ module Formtastic
     # Rails doesn't come with a `country_select` helper by default any more, so you'll need to do
     # one of the following:
     #
-    # * install [the official Rails plugin](http://github.com/rails/iso-3166-country-select)
+    # * install the [country-select](https://github.com/jamesds/country-select) gem
+    # * install the no longer maintained [official Rails plugin](http://github.com/rails/iso-3166-country-select)
     # * install any other country_select plugin that behaves in a similar way
     # * roll your own `country_select` helper with the same args and options as the Rails one
     #
@@ -50,7 +51,7 @@ module Formtastic
       include Base
 
       def to_html
-        raise "To use the :country input, please install a country_select plugin, like this one: http://github.com/rails/iso-3166-country-select" unless builder.respond_to?(:country_select)
+        raise "To use the :country input, please install a country_select plugin, like this one: https://github.com/jamesds/country-select" unless builder.respond_to?(:country_select)
         input_wrapping do
           label_html <<
           builder.country_select(method, priority_countries, input_options, input_html_options)


### PR DESCRIPTION
The official rails country_select plugin https://github.com/rails/iso-3166-country-select is no longer maintained and has not been updated since 2008. There is now a country-select gem which works better at https://github.com/jamesds/country-select. I have updated the inline documentation as well as the error message to reflect this fact.
