### PR TITLE
Flatten only 1 level deep when passing to fields_for. Fixes #786.

### DIFF
--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -380,7 +380,7 @@ module Formtastic
           end
         end
 
-        fields_for_args = [options.delete(:for), options.delete(:for_options) || {}].flatten
+        fields_for_args = [options.delete(:for), options.delete(:for_options) || {}].flatten(1)
         fields_for(*fields_for_args, &fields_for_block)
       end
 


### PR DESCRIPTION
All tests are green (for all rails versions).
