### PR TITLE
Don't add the checkbox's name attribute to its label for boolean fields.

### DIFF
--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -57,8 +57,9 @@ module Formtastic
         
         input_html_options.merge(
           prev.merge(
-            :id => nil,
-            :for => input_html_options[:id]
+            :id   => nil,
+            :name => nil,
+            :for  => input_html_options[:id]
           )
         )
       end

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -29,6 +29,10 @@ describe 'boolean input' do
     output_buffer.should_not have_tag('form li label input[@type="hidden"]', :count => 1) # invalid HTML5
   end
 
+  it 'should not add a "name" attribute to the label' do
+    output_buffer.should_not have_tag('form li label[@name]')
+  end
+
   it 'should generate a checkbox input' do
     output_buffer.should have_tag('form li label input')
     output_buffer.should have_tag('form li label input#post_allow_comments')


### PR DESCRIPTION
... which was causing HTML validation errors.
