### PR TITLE
Add HTML5 date, time & datetime inputs for use with JS date pickers, etc

### DIFF
--- a/lib/formtastic/inputs.rb
+++ b/lib/formtastic/inputs.rb
@@ -8,6 +8,8 @@ module Formtastic
     autoload :CheckBoxesInput
     autoload :CountryInput
     autoload :DateInput
+    autoload :DatePickerInput
+    autoload :DatetimePickerInput
     autoload :DatetimeInput
     autoload :EmailInput
     autoload :FileInput
@@ -23,6 +25,7 @@ module Formtastic
     autoload :StringInput
     autoload :TextInput
     autoload :TimeInput
+    autoload :TimePickerInput
     autoload :TimeZoneInput
     autoload :Timeish
     autoload :UrlInput

--- a/lib/formtastic/inputs/base.rb
+++ b/lib/formtastic/inputs/base.rb
@@ -42,6 +42,7 @@ module Formtastic
       
       extend ActiveSupport::Autoload
       
+      autoload :DatetimePickerish
       autoload :Associations
       autoload :Collections
       autoload :Choices
@@ -63,6 +64,7 @@ module Formtastic
       
       include Html
       include Options
+      include Database
       include Database
       include Errors
       include Hints

--- a/lib/formtastic/inputs/base/datetime_pickerish.rb
+++ b/lib/formtastic/inputs/base/datetime_pickerish.rb
@@ -1,0 +1,85 @@
+module Formtastic
+  module Inputs
+    module Base
+      module DatetimePickerish
+        include Base::Placeholder
+      
+        def html_input_type
+          raise NotImplementedError
+        end
+      
+        def default_size
+          raise NotImplementedError
+        end
+        
+        def value
+          raise NotImplementedError
+        end
+      
+        def input_html_options
+          super.merge(extra_input_html_options)
+        end
+      
+        def extra_input_html_options
+          {
+            :type => html_input_type, 
+            :size => size, 
+            :maxlength => maxlength, 
+            :step => step,
+            :value => value
+          }
+        end
+      
+        def size
+          return options[:size] if options.key?(:size)
+          return options[:input_html][:size] if options[:input_html] && options[:input_html].key?(:size)
+          default_size
+        end
+      
+        def step
+          return step_from_macro(options[:input_html][:step]) if options[:input_html] && options[:input_html][:step] && options[:input_html][:step].is_a?(Symbol)
+          return options[:input_html][:step] if options[:input_html] && options[:input_html].key?(:step)
+          default_step
+        end
+      
+        def maxlength
+          return options[:maxlength] if options.key?(:maxlength)
+          return options[:input_html][:maxlength] if options[:input_html] && options[:input_html].key?(:maxlength)
+          default_size
+        end
+      
+        def default_maxlength
+          default_size
+        end
+      
+        def default_step
+          1
+        end
+        
+        protected
+        
+        def step_from_macro(sym)
+          case sym
+
+            # date
+            when :day then "1"
+            when :seven_days, :week then "7"
+            when :two_weeks, :fortnight then "14"
+            when :four_weeks then "28"
+            when :thirty_days then "30"
+
+            # time
+            when :second then "1"
+            when :minute then "60"
+            when :fifteen_minutes, :quarter_hour then "900"
+            when :thirty_minutes, :half_hour then "1800"
+            when :sixty_minutes, :hour then "3600"            
+
+            else sym
+          end
+        end
+        
+      end
+    end
+  end
+end

--- a/lib/formtastic/inputs/base/stringish.rb
+++ b/lib/formtastic/inputs/base/stringish.rb
@@ -14,9 +14,17 @@ module Formtastic
         # Overrides standard `input_html_options` to provide a `maxlength` and `size` attribute.
         def input_html_options
           {
-            :maxlength => options[:input_html].try(:[], :maxlength) || limit,
-            :size => builder.default_text_field_size
+            :maxlength => maxlength,
+            :size => size
           }.merge(super)
+        end
+        
+        def size
+          builder.default_text_field_size
+        end
+        
+        def maxlength
+          options[:input_html].try(:[], :maxlength) || limit
         end
         
         def wrapper_html_options

--- a/lib/formtastic/inputs/date_picker_input.rb
+++ b/lib/formtastic/inputs/date_picker_input.rb
@@ -1,0 +1,93 @@
+module Formtastic
+  module Inputs
+    
+    # Outputs a simple `<label>` with a HTML5 `<input type="date">` wrapped in the standard
+    # `<li>` wrapper. This is an alternative to `:date_select` for `:date`, `:time`, `:datetime` 
+    # database columns. You can use this input with `:as => :date_picker`.
+    #
+    # *Please note:* Formtastic only provides suitable markup for a date picker, but does not supply
+    # any additional CSS or Javascript to render calendar-style date pickers. Browsers that support
+    # this input type (such as Mobile Webkit and Opera on the desktop) will render a native widget.
+    # Browsers that don't will default to a plain text field`<input type="text">` and can be 
+    # poly-filled with some Javascript and a UI library of your choice.
+    #
+    # @example Full form context and output
+    #
+    #   <%= semantic_form_for(@post) do |f| %>
+    #     <%= f.inputs do %>
+    #       <%= f.input :publish_at, :as => :date_picker %>
+    #     <% end %>
+    #   <% end %>
+    #
+    #   <form...>
+    #     <fieldset>
+    #       <ol>
+    #         <li class="string">
+    #           <label for="post_publish_at">First name</label>
+    #           <input type="date" id="post_publish_at" name="post[publish_at]">
+    #         </li>
+    #       </ol>
+    #     </fieldset>
+    #   </form>
+    #
+    # @example Setting the size (defaults to 10 for YYYY-MM-DD)
+    #   <%= f.input :publish_at, :as => :date_picker, :size => 20 %>
+    #   <%= f.input :publish_at, :as => :date_picker, :input_html => { :size => 20 } %>
+    #
+    # @example Setting the maxlength (defaults to 10 for YYYY-MM-DD)
+    #   <%= f.input :publish_at, :as => :date_picker, :maxlength => 20 %>
+    #   <%= f.input :publish_at, :as => :date_picker, :input_html => { :maxlength => 20 } %>
+    #
+    # @example Setting the value (defaults to YYYY-MM-DD for Date and Time objects, otherwise renders string)
+    #   <%= f.input :publish_at, :as => :date_picker, :input_html => { :value => "1970-01-01" } %>
+    #
+    # @example Setting the step attribute (defaults to 1)
+    #   <%= f.input :publish_at, :as => :date_picker, :step => 7 %>
+    #   <%= f.input :publish_at, :as => :date_picker, :input_html => { :step => 7 } %>
+    #
+    # @example Setting the step attribute with a macro
+    #   <%= f.input :publish_at, :as => :date_picker, :step => :day %>
+    #   <%= f.input :publish_at, :as => :date_picker, :step => :week %>
+    #   <%= f.input :publish_at, :as => :date_picker, :step => :seven_days %>
+    #   <%= f.input :publish_at, :as => :date_picker, :step => :fortnight %>
+    #   <%= f.input :publish_at, :as => :date_picker, :step => :two_weeks %>
+    #   <%= f.input :publish_at, :as => :date_picker, :step => :four_weeks %>
+    #   <%= f.input :publish_at, :as => :date_picker, :step => :thirty_days %>
+    #
+    # @example Setting the min attribute
+    #   <%= f.input :publish_at, :as => :date_picker, :min => "2012-01-01" %>
+    #   <%= f.input :publish_at, :as => :date_picker, :input_html => { :min => "2012-01-01" } %>
+    #
+    # @example Setting the max attribute
+    #   <%= f.input :publish_at, :as => :date_picker, :max => "2012-12-31" %>
+    #   <%= f.input :publish_at, :as => :date_picker, :input_html => { :max => "2012-12-31" } %>
+    #
+    # @example Setting the placeholder attribute
+    #   <%= f.input :publish_at, :as => :date_picker, :placeholder => 20 %>
+    #   <%= f.input :publish_at, :as => :date_picker, :input_html => { :placeholder => "YYYY-MM-DD" } %>
+    #
+    # @see Formtastic::Helpers::InputsHelper#input InputsHelper#input for full documentation of all possible options.
+    class DatePickerInput
+      include Base
+      include Base::Stringish
+      include Base::DatetimePickerish
+      
+      def html_input_type
+        "date"
+      end
+      
+      def default_size
+        10
+      end
+      
+      def value
+        return options[:input_html][:value] if options[:input_html] && options[:input_html].key?(:value)
+        val = object.send(method)
+        return Date.new(val.year, val.month, val.day).to_s if val.is_a?(Time)
+        return val if val.nil?
+        val.to_s
+      end
+      
+    end
+  end
+end

--- a/lib/formtastic/inputs/datetime_picker_input.rb
+++ b/lib/formtastic/inputs/datetime_picker_input.rb
@@ -1,0 +1,100 @@
+module Formtastic
+  module Inputs
+    
+    # Outputs a simple `<label>` with a HTML5 `<input type="datetime-local">` (or 
+    # `<input type="datetime">`) wrapped in the standard `<li>` wrapper. This is an alternative to 
+    # `:date_select` for `:date`, `:time`, `:datetime` database columns. You can use this input with
+    # `:as => :datetime_picker`.
+    #
+    # *Please note:* Formtastic only provides suitable markup for a date picker, but does not supply
+    # any additional CSS or Javascript to render calendar-style date pickers. Browsers that support
+    # this input type (such as Mobile Webkit and Opera on the desktop) will render a native widget.
+    # Browsers that don't will default to a plain text field`<input type="text">` and can be 
+    # poly-filled with some Javascript and a UI library of your choice.
+    #
+    # @example Full form context and output
+    #
+    #   <%= semantic_form_for(@post) do |f| %>
+    #     <%= f.inputs do %>
+    #       <%= f.input :publish_at, :as => :datetime_picker %>
+    #     <% end %>
+    #   <% end %>
+    #
+    #   <form...>
+    #     <fieldset>
+    #       <ol>
+    #         <li class="string">
+    #           <label for="post_publish_at">First name</label>
+    #           <input type="date" id="post_publish_at" name="post[publish_at]">
+    #         </li>
+    #       </ol>
+    #     </fieldset>
+    #   </form>
+    #
+    # @example Setting the size (defaults to 16 for YYYY-MM-DD HH:MM)
+    #   <%= f.input :publish_at, :as => :datetime_picker, :size => 20 %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :input_html => { :size => 20 } %>
+    #
+    # @example Setting the maxlength (defaults to 16 for YYYY-MM-DD HH:MM)
+    #   <%= f.input :publish_at, :as => :datetime_picker, :maxlength => 20 %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :input_html => { :maxlength => 20 } %>
+    #
+    # @example Setting the value (defaults to YYYY-MM-DD HH:MM for Date and Time objects, otherwise renders string)
+    #   <%= f.input :publish_at, :as => :datetime_picker, :input_html => { :value => "1970-01-01 00:00" } %>
+    #
+    # @example Setting the step attribute (defaults to 1)
+    #   <%= f.input :publish_at, :as => :datetime_picker, :step => 60 %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :input_html => { :step => 60 } %>
+    #
+    # @example Setting the step attribute with a macro
+    #   <%= f.input :publish_at, :as => :datetime_picker, :step => :second %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :step => :minute %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :step => :quarter_hour %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :step => :fifteen_minutes %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :step => :half_hour %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :step => :thirty_minutes %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :step => :hour %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :step => :sixty_minutes %>
+    #
+    # @example Setting the min attribute
+    #   <%= f.input :publish_at, :as => :datetime_picker, :min => "2012-01-01 09:00" %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :input_html => { :min => "2012-01-01 09:00" } %>
+    #
+    # @example Setting the max attribute
+    #   <%= f.input :publish_at, :as => :datetime_picker, :max => "2012-12-31 16:00" %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :input_html => { :max => "2012-12-31 16:00" } %>
+    #
+    # @example Setting the placeholder attribute
+    #   <%= f.input :publish_at, :as => :datetime_picker, :placeholder => "YYYY-MM-DD HH:MM" %>
+    #   <%= f.input :publish_at, :as => :datetime_picker, :input_html => { :placeholder => "YYYY-MM-DD HH:MM" } %>
+    #
+    # @example Using `datetime` (UTC) or `datetime-local` with `:local` (defaults to true, `datetime-local` input)
+    #   <%= f.input :publish_at, :as => :datetime_picker, :local => false %>
+    #
+    # @see Formtastic::Helpers::InputsHelper#input InputsHelper#input for full documentation of all possible options.
+    class DatetimePickerInput
+      include Base
+      include Base::Stringish
+      include Base::DatetimePickerish
+      
+      def html_input_type
+        options[:local] = true unless options.key?(:local)
+        options[:local] ? "datetime-local" : "datetime"
+      end
+      
+      def default_size
+        16
+      end
+      
+      def value
+        return options[:input_html][:value] if options[:input_html] && options[:input_html].key?(:value)
+        val = object.send(method)
+        return val.strftime("%Y-%m-%d %H:%M") if val.is_a?(Time)
+        return "#{val.year}-#{val.month}-#{val.day} 00:00" if val.is_a?(Date)
+        return val if val.nil?
+        val.to_s
+      end
+      
+    end
+  end
+end

--- a/lib/formtastic/inputs/time_picker_input.rb
+++ b/lib/formtastic/inputs/time_picker_input.rb
@@ -1,0 +1,99 @@
+module Formtastic
+  module Inputs
+    
+    # Outputs a simple `<label>` with a HTML5 `<input type="time">` wrapped in the standard
+    # `<li>` wrapper. This is an alternative to `:time_select` for `:date`, `:time`, `:datetime` 
+    # database columns. You can use this input with `:as => :time_picker`.
+    #
+    # *Please note:* Formtastic only provides suitable markup for a date picker, but does not supply
+    # any additional CSS or Javascript to render calendar-style date pickers. Browsers that support
+    # this input type (such as Mobile Webkit and Opera on the desktop) will render a native widget.
+    # Browsers that don't will default to a plain text field`<input type="text">` and can be 
+    # poly-filled with some Javascript and a UI library of your choice.
+    #
+    # @example Full form context and output
+    #
+    #   <%= semantic_form_for(@post) do |f| %>
+    #     <%= f.inputs do %>
+    #       <%= f.input :publish_at, :as => :time_picker %>
+    #     <% end %>
+    #   <% end %>
+    #
+    #   <form...>
+    #     <fieldset>
+    #       <ol>
+    #         <li class="string">
+    #           <label for="post_publish_at">First name</label>
+    #           <input type="date" id="post_publish_at" name="post[publish_at]">
+    #         </li>
+    #       </ol>
+    #     </fieldset>
+    #   </form>
+    #
+    # @example Setting the size (defaults to 5 for HH:MM)
+    #   <%= f.input :publish_at, :as => :time_picker, :size => 20 %>
+    #   <%= f.input :publish_at, :as => :time_picker, :input_html => { :size => 20 } %>
+    #
+    # @example Setting the maxlength (defaults to 5 for HH:MM)
+    #   <%= f.input :publish_at, :as => :time_picker, :maxlength => 20 %>
+    #   <%= f.input :publish_at, :as => :time_picker, :input_html => { :maxlength => 20 } %>
+    #
+    # @example Setting the value (defaults to HH:MM for Date and Time objects, otherwise renders string)
+    #   <%= f.input :publish_at, :as => :time_picker, :input_html => { :value => "14:14" } %>
+    #
+    # @example Setting the step attribute (defaults to 60)
+    #   <%= f.input :publish_at, :as => :time_picker, :step => 120 %>
+    #   <%= f.input :publish_at, :as => :time_picker, :input_html => { :step => 120 } %>
+    #
+    # @example Setting the step attribute with a macro
+    #   <%= f.input :publish_at, :as => :time_picker, :step => :second %>
+    #   <%= f.input :publish_at, :as => :time_picker, :step => :minute %>
+    #   <%= f.input :publish_at, :as => :time_picker, :step => :quarter_hour %>
+    #   <%= f.input :publish_at, :as => :time_picker, :step => :fifteen_minutes %>
+    #   <%= f.input :publish_at, :as => :time_picker, :step => :half_hour %>
+    #   <%= f.input :publish_at, :as => :time_picker, :step => :thirty_minutes %>
+    #   <%= f.input :publish_at, :as => :time_picker, :step => :hour %>
+    #   <%= f.input :publish_at, :as => :time_picker, :step => :sixty_minutes %>
+    #
+    # @example Setting the min attribute
+    #   <%= f.input :publish_at, :as => :time_picker, :min => "09:00" %>
+    #   <%= f.input :publish_at, :as => :time_picker, :input_html => { :min => "01:00" } %>
+    #
+    # @example Setting the max attribute
+    #   <%= f.input :publish_at, :as => :time_picker, :max => "18:00" %>
+    #   <%= f.input :publish_at, :as => :time_picker, :input_html => { :max => "18:00" } %>
+    #
+    # @example Setting the placeholder attribute
+    #   <%= f.input :publish_at, :as => :time_picker, :placeholder => "HH:MM" %>
+    #   <%= f.input :publish_at, :as => :time_picker, :input_html => { :placeholder => "HH:MM" } %>
+    #
+    # @see Formtastic::Helpers::InputsHelper#input InputsHelper#input for full documentation of all possible options.
+    class TimePickerInput
+      include Base
+      include Base::Stringish
+      include Base::DatetimePickerish
+      
+      def html_input_type
+        "time"
+      end
+      
+      def default_size
+        5
+      end
+      
+      def value
+        return options[:input_html][:value] if options[:input_html] && options[:input_html].key?(:value)
+        val = object.send(method)
+        return "00:00" if val.is_a?(Date)
+        return val.strftime("%H:%M") if val.is_a?(Time)
+        return val if val.nil?
+        val.to_s
+      end
+      
+      def default_step
+        60
+      end
+      
+    end
+  end
+end

--- a/sample/basic_inputs.html
+++ b/sample/basic_inputs.html
@@ -101,7 +101,27 @@
             </ol>
           </fieldset>
         </li>
-
+        
+        <li class="input date_picker optional">
+          <label class="label" for="gem_expiry">Expiry date</label>
+          <input id="gem_expiry" name="gem[gem_expiry]" type="date" size="10" maxlength="10" min="2012-01-01" max="2012-12-31" step="1" value="2012-01-01">
+        </li>
+        
+        <li class="input datetime_picker optional">
+          <label class="label" for="gem_expiry">Expiry datetime-local</label>
+          <input id="gem_expiry" name="gem[gem_expiry]" type="datetime-local" size="16" maxlength="16" min="2012-01-01T00:00" max="2012-12-31T23:59" step="1800">
+        </li>
+        
+        <li class="input datetime_picker optional">
+          <label class="label" for="gem_expiry">Expiry datetime</label>
+          <input id="gem_expiry" name="gem[gem_expiry]" type="datetime" size="16" maxlength="16" min="2012-01-01T00:00" max="2012-12-31T23:59" step="1800">
+        </li>
+        
+        <li class="input time_picker optional">
+          <label class="label" for="gem_expiry">Expiry time</label>
+          <input id="gem_expiry" name="gem[gem_expiry]" type="time" size="5" maxlength="5" min="T00:00" max="23:59" step="60">
+        </li>
+        
         <li class="input string stringish optional autofocus" id="gem_autofocus_input">
           <label class="label" for="gem_autofocus">Autofocus</label>
           <input id="gem_autofocus" name="gem[autofocus]" type="text" value="The focus is set to this field" autofocus="autofocus">

--- a/spec/inputs/date_picker_input_spec.rb
+++ b/spec/inputs/date_picker_input_spec.rb
@@ -1,0 +1,449 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe 'date_picker input' do
+
+  include FormtasticSpecHelper
+
+  before do
+    @output_buffer = ''
+    mock_everything
+  end
+  
+  context "with an object" do
+    before do
+      concat(semantic_form_for(@new_post) do |builder|
+        concat(builder.input(:publish_at, :as => :date_picker))
+      end)
+    end
+    
+    it_should_have_input_wrapper_with_class(:date_picker)
+    it_should_have_input_wrapper_with_class(:input)
+    it_should_have_input_wrapper_with_class(:stringish)
+    it_should_have_input_wrapper_with_id("post_publish_at_input")
+    it_should_have_label_with_text(/Publish at/)
+    it_should_have_label_for("post_publish_at")
+    it_should_have_input_with_id("post_publish_at")
+    it_should_have_input_with_type(:date)
+    it_should_have_input_with_name("post[publish_at]")
+    it_should_apply_custom_input_attributes_when_input_html_provided(:date_picker)
+    it_should_apply_custom_for_to_label_when_input_html_id_provided(:date_picker)
+    # TODO why does this blow-up it_should_apply_error_logic_for_input_type(:date_picker)
+    
+  end
+  
+  describe "size attribute" do
+    
+    it "defaults to 10 chars (YYYY-YY-YY)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker))
+        end
+      )
+      output_buffer.should have_tag "input[size='10']"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker, :input_html => { :size => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[size='11']"
+    end
+    
+    it "can be set from options (ignoring input_html)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker, :size => '12', :input_html => { :size => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[size='12']"
+    end
+
+  end
+
+  describe "maxlength attribute" do
+
+    it "defaults to 10 chars (YYYY-YY-YY)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker))
+        end
+      )
+      output_buffer.should have_tag "input[maxlength='10']"
+    end
+
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker, :input_html => { :maxlength => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[maxlength='11']"
+    end
+    
+    it "can be set from options (ignoring input_html)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker, :maxlength => 12, :input_html => { :maxlength => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[maxlength='12']"
+    end
+    
+  end
+  
+  describe "value attribute" do
+  
+    context "when method returns nil" do
+      
+      it "has no value" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker ))
+          end
+        )
+        output_buffer.should_not have_tag "li input[value]"
+      end
+      
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker, :input_html => { :value => "1111-11-11" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11']"
+      end
+      
+    end
+  
+    context "when method returns a Date" do
+      
+      before do
+        @date = Date.new(2000, 11, 11)
+        @new_post.stub!(:publish_at).and_return(@date)
+      end
+      
+      it "renders the date as YYYY-MM-DD" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='#{@date.to_s}']"
+      end
+
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker, :input_html => { :value => "1111-11-11" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11']"
+      end
+      
+    end
+  
+    context "when method returns a Time" do
+    
+      before do
+        @time = Time.utc(2000,11,11,11,11,11)
+        @new_post.stub!(:publish_at).and_return(@time)
+      end
+      
+      it "renders the time as a YYYY-MM-DD" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='2000-11-11']"
+      end
+    
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker, :input_html => { :value => "1111-11-11" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11']"
+      end
+      
+    end
+  
+    context "when method returns an empty String" do
+      
+      before do
+        @new_post.stub!(:publish_at).and_return("")
+      end
+      
+      it "will be empty" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='']"
+      end
+      
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker, :input_html => { :value => "1111-11-11" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11']"
+      end
+      
+    end
+  
+    context "when method returns a String" do
+      
+      before do
+        @new_post.stub!(:publish_at).and_return("yeah")
+      end
+      
+      it "will be the string" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='yeah']"
+      end
+    
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker, :input_html => { :value => "1111-11-11" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11']"
+      end
+      
+    end
+
+  end
+  
+  describe "min attribute" do
+    
+    it "will be omitted by default" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker))
+        end
+      )
+      output_buffer.should_not have_tag "input[min]"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker, :input_html => { :min => "1970-01-01" }))
+        end
+      )
+      output_buffer.should have_tag "input[min='1970-01-01']"
+    end
+    
+  end
+  
+  describe "max attribute" do
+
+    it "will be omitted by default" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker))
+        end
+      )
+      output_buffer.should_not have_tag "input[max]"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker, :input_html => { :max => "1970-01-01" }))
+        end
+      )
+      output_buffer.should have_tag "input[max='1970-01-01']"
+    end
+    
+  end
+  
+  describe "step attribute" do
+    
+    it "defaults to 1" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker))
+        end
+      )
+      output_buffer.should have_tag "input[step='1']"
+    end
+
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker, :input_html => { :step => "5" }))
+        end
+      )
+      output_buffer.should have_tag "input[step='5']"
+    end
+    
+    describe "macros" do
+      
+      before do 
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker, :input_html => { :step => step }))
+          end
+        )
+      end
+      
+      context ":day" do
+        let(:step) { :day }
+        it "uses 1" do
+          output_buffer.should have_tag "input[step='1']"
+        end
+      end
+      
+      context ":seven_days" do
+        let(:step) { :seven_days }
+        it "uses 7" do
+          output_buffer.should have_tag "input[step='7']"
+        end
+      end
+      
+      context ":week" do
+        let(:step) { :week }
+        it "uses 7" do
+          output_buffer.should have_tag "input[step='7']"
+        end
+      end
+      
+      context ":fortnight" do
+        let(:step) { :fortnight }
+        it "uses 14" do
+          output_buffer.should have_tag "input[step='14']"
+        end
+      end
+      
+      context ":two_weeks" do
+        let(:step) { :two_weeks }
+        it "uses 14" do
+          output_buffer.should have_tag "input[step='14']"
+        end
+      end
+      
+      context ":four_weeks" do
+        let(:step) { :four_weeks }
+        it "uses 28" do
+          output_buffer.should have_tag "input[step='28']"
+        end
+      end
+      
+      context ":thirty_days" do
+        let(:step) { :thirty_days }
+        it "uses 30" do
+          output_buffer.should have_tag "input[step='30']"
+        end
+      end
+      
+    end
+    
+  end
+  
+  describe "placeholder attribute" do
+    
+    it "will be omitted" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker))
+        end
+      )
+      output_buffer.should_not have_tag "input[placeholder]"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :date_picker, :input_html => { :placeholder => "1970-01-01" }))
+        end
+      )
+      output_buffer.should have_tag "input[placeholder='1970-01-01']"
+    end
+    
+    context "with i18n set" do
+      before do
+        ::I18n.backend.store_translations :en, :formtastic => { :placeholders => { :publish_at => 'YYYY-MM-DD' }}
+      end
+      
+      it "can be set with i18n" do
+        with_config :i18n_lookups_by_default, true do
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(:publish_at, :as => :date_picker))
+          end)
+          output_buffer.should have_tag('input[@placeholder="YYYY-MM-DD"]')
+        end
+      end
+      
+      it "can be set with input_html, trumping i18n" do
+        with_config :i18n_lookups_by_default, true do
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(:publish_at, :as => :date_picker, :input_html => { :placeholder => "Something" }))
+          end)
+          output_buffer.should have_tag('input[@placeholder="Something"]')
+        end
+      end
+    end
+    
+  end
+  
+  describe "when namespace is provided" do
+    before do
+      concat(semantic_form_for(@new_post, :namespace => "context2") do |builder|
+        concat(builder.input(:publish_at, :as => :date_picker))
+      end)
+    end
+
+    it_should_have_input_wrapper_with_id("context2_post_publish_at_input")
+    it_should_have_label_and_input_with_id("context2_post_publish_at")
+  end
+  
+  describe "when index is provided" do
+    before do
+      @output_buffer = ''
+      mock_everything
+
+      concat(semantic_form_for(@new_post) do |builder|
+        concat(builder.fields_for(:author, :index => 3) do |author|
+          concat(author.input(:created_at, :as => :date_picker))
+        end)
+      end)
+    end
+    
+    it 'should index the id of the wrapper' do
+      output_buffer.should have_tag("li#post_author_attributes_3_created_at_input")
+    end
+    
+    it 'should index the id of the select tag' do
+      output_buffer.should have_tag("input#post_author_attributes_3_created_at")
+    end
+    
+    it 'should index the name of the select tag' do
+      output_buffer.should have_tag("input[@name='post[author_attributes][3][created_at]']")
+    end
+  end
+  
+  describe "when required" do
+    it "should add the required attribute to the input's html options" do
+      with_config :use_required_attribute, true do 
+        concat(semantic_form_for(@new_post) do |builder|
+          concat(builder.input(:publish_at, :as => :date_picker, :required => true))
+        end)
+        output_buffer.should have_tag("input[@required]")
+      end
+    end
+  end
+  
+end

--- a/spec/inputs/datetime_picker_input_spec.rb
+++ b/spec/inputs/datetime_picker_input_spec.rb
@@ -1,0 +1,490 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe 'datetime_picker input' do
+
+  include FormtasticSpecHelper
+
+  before do
+    @output_buffer = ''
+    mock_everything
+  end
+  
+  after do
+    ::I18n.backend.reload!
+  end
+  
+  context "with an object" do
+    before do
+      concat(semantic_form_for(@new_post) do |builder|
+        concat(builder.input(:publish_at, :as => :datetime_picker))
+      end)
+    end
+    
+    it_should_have_input_wrapper_with_class(:datetime_picker)
+    it_should_have_input_wrapper_with_class(:input)
+    it_should_have_input_wrapper_with_class(:stringish)
+    it_should_have_input_wrapper_with_id("post_publish_at_input")
+    it_should_have_label_with_text(/Publish at/)
+    it_should_have_label_for("post_publish_at")
+    it_should_have_input_with_id("post_publish_at")
+    it_should_have_input_with_type("datetime-local")
+    it_should_have_input_with_name("post[publish_at]")
+    it_should_apply_custom_input_attributes_when_input_html_provided(:datetime_picker)
+    it_should_apply_custom_for_to_label_when_input_html_id_provided(:datetime_picker)
+    # TODO why does this blow-up it_should_apply_error_logic_for_input_type(:datetime_picker)
+    
+  end
+  
+  describe ":local option for UTC or local time" do
+    
+    it "should default to a datetime-local input (true)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker))
+        end
+      )
+      output_buffer.should have_tag "input[type='datetime-local']"
+    end
+    
+    it "can be set to true for a datetime-local" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :local => true))
+        end
+      )
+      output_buffer.should have_tag "input[type='datetime-local']"
+    end
+
+    it "can be set to false for a datetime" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :local => false))
+        end
+      )
+      output_buffer.should have_tag "input[type='datetime']"
+    end
+    
+  end
+  
+  describe "size attribute" do
+    
+    it "defaults to 10 chars (YYYY-YY-YY HH:MM)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker))
+        end
+      )
+      output_buffer.should have_tag "input[size='16']"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :size => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[size='11']"
+    end
+    
+    it "can be set from options (ignoring input_html)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :size => '12', :input_html => { :size => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[size='12']"
+    end
+
+  end
+
+  describe "maxlength attribute" do
+
+    it "defaults to 10 chars (YYYY-YY-YY HH:MM)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker))
+        end
+      )
+      output_buffer.should have_tag "input[maxlength='16']"
+    end
+
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :maxlength => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[maxlength='11']"
+    end
+    
+    it "can be set from options (ignoring input_html)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :maxlength => 12, :input_html => { :maxlength => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[maxlength='12']"
+    end
+    
+  end
+  
+  describe "value attribute" do
+  
+    context "when method returns nil" do
+      
+      it "has no value" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker ))
+          end
+        )
+        output_buffer.should_not have_tag "li input[value]"
+      end
+      
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :value => "1111-11-11 23:00" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11 23:00']"
+      end
+      
+    end
+  
+    context "when method returns a Date" do
+      
+      before do
+        @date = Date.new(2000, 11, 11)
+        @new_post.stub!(:publish_at).and_return(@date)
+      end
+      
+      it "renders the date as YYYY-MM-DD 00:00" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='#{@date.to_s} 00:00']"
+      end
+
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :value => "1111-11-11 00:00" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11 00:00']"
+      end
+      
+    end
+  
+    context "when method returns a Time" do
+    
+      before do
+        @time = Time.utc(2000,11,11,11,11,11)
+        @new_post.stub!(:publish_at).and_return(@time)
+      end
+      
+      it "renders the time as a YYYY-MM-DD HH:MM" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='2000-11-11 11:11']"
+      end
+    
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :value => "1111-11-11 11:11" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11 11:11']"
+      end
+      
+    end
+  
+    context "when method returns an empty String" do
+      
+      before do
+        @new_post.stub!(:publish_at).and_return("")
+      end
+      
+      it "will be empty" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='']"
+      end
+      
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :value => "1111-11-11 11:11" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11 11:11']"
+      end
+      
+    end
+  
+    context "when method returns a String" do
+      
+      before do
+        @new_post.stub!(:publish_at).and_return("yeah")
+      end
+      
+      it "will be the string" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='yeah']"
+      end
+    
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :value => "1111-11-11 11:11" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='1111-11-11 11:11']"
+      end
+      
+    end
+
+  end
+  
+  describe "min attribute" do
+    
+    it "will be omitted by default" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker))
+        end
+      )
+      output_buffer.should_not have_tag "input[min]"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :min => "1970-01-01 12:00" }))
+        end
+      )
+      output_buffer.should have_tag "input[min='1970-01-01 12:00']"
+    end
+    
+  end
+  
+  describe "max attribute" do
+
+    it "will be omitted by default" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker))
+        end
+      )
+      output_buffer.should_not have_tag "input[max]"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :max => "1970-01-01 12:00" }))
+        end
+      )
+      output_buffer.should have_tag "input[max='1970-01-01 12:00']"
+    end
+    
+  end
+  
+  describe "step attribute" do
+    
+    it "defaults to 1" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker))
+        end
+      )
+      output_buffer.should have_tag "input[step='1']"
+    end
+
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :step => "5" }))
+        end
+      )
+      output_buffer.should have_tag "input[step='5']"
+    end
+    
+    describe "macros" do
+      before do 
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :step => step }))
+          end
+        )
+      end
+      
+      context ":second" do
+        let(:step) { :second }
+        it "uses 1" do
+          output_buffer.should have_tag "input[step='1']"
+        end
+      end
+      
+      context ":minute" do
+        let(:step) { :minute }
+        it "uses 60" do
+          output_buffer.should have_tag "input[step='60']"
+        end
+      end
+      
+      context ":fifteen_minutes" do
+        let(:step) { :fifteen_minutes }
+        it "uses 900" do
+          output_buffer.should have_tag "input[step='900']"
+        end
+      end
+      
+      context ":quarter_hour" do
+        let(:step) { :quarter_hour }
+        it "uses 900" do
+          output_buffer.should have_tag "input[step='900']"
+        end
+      end
+      
+      context ":thirty_minutes" do
+        let(:step) { :thirty_minutes }
+        it "uses 1800" do
+          output_buffer.should have_tag "input[step='1800']"
+        end
+      end
+      
+      context ":half_hour" do
+        let(:step) { :half_hour }
+        it "uses 1800" do
+          output_buffer.should have_tag "input[step='1800']"
+        end
+      end
+      
+      context ":hour" do
+        let(:step) { :hour }
+        it "uses 3600" do
+          output_buffer.should have_tag "input[step='3600']"
+        end
+      end
+      
+      context ":sixty_minutes" do
+        let(:step) { :sixty_minutes }
+        it "uses 3600" do
+          output_buffer.should have_tag "input[step='3600']"
+        end
+      end
+      
+    end
+    
+  end
+  
+  describe "placeholder attribute" do
+    
+    it "will be omitted" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker))
+        end
+      )
+      output_buffer.should_not have_tag "input[placeholder]"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :datetime_picker, :input_html => { :placeholder => "1970-01-01 00:00" }))
+        end
+      )
+      output_buffer.should have_tag "input[placeholder='1970-01-01 00:00']"
+    end
+    
+    context "with i18n set" do
+      before do
+        ::I18n.backend.store_translations :en, :formtastic => { :placeholders => { :publish_at => 'YYYY-MM-DD HH:MM' }}
+      end
+      
+      it "can be set with i18n" do
+        with_config :i18n_lookups_by_default, true do
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(:publish_at, :as => :datetime_picker))
+          end)
+          output_buffer.should have_tag('input[@placeholder="YYYY-MM-DD HH:MM"]')
+        end
+      end
+      
+      it "can be set with input_html, trumping i18n" do
+        with_config :i18n_lookups_by_default, true do
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(:publish_at, :as => :datetime_picker, :input_html => { :placeholder => "Something" }))
+          end)
+          output_buffer.should have_tag('input[@placeholder="Something"]')
+        end
+      end
+    end
+    
+  end
+  
+  describe "when namespace is provided" do
+    before do
+      concat(semantic_form_for(@new_post, :namespace => "context2") do |builder|
+        concat(builder.input(:publish_at, :as => :datetime_picker))
+      end)
+    end
+
+    it_should_have_input_wrapper_with_id("context2_post_publish_at_input")
+    it_should_have_label_and_input_with_id("context2_post_publish_at")
+  end
+  
+  describe "when index is provided" do
+    before do
+      @output_buffer = ''
+      mock_everything
+
+      concat(semantic_form_for(@new_post) do |builder|
+        concat(builder.fields_for(:author, :index => 3) do |author|
+          concat(author.input(:created_at, :as => :datetime_picker))
+        end)
+      end)
+    end
+    
+    it 'should index the id of the wrapper' do
+      output_buffer.should have_tag("li#post_author_attributes_3_created_at_input")
+    end
+    
+    it 'should index the id of the select tag' do
+      output_buffer.should have_tag("input#post_author_attributes_3_created_at")
+    end
+    
+    it 'should index the name of the select tag' do
+      output_buffer.should have_tag("input[@name='post[author_attributes][3][created_at]']")
+    end
+  end
+  
+  describe "when required" do
+    it "should add the required attribute to the input's html options" do
+      with_config :use_required_attribute, true do 
+        concat(semantic_form_for(@new_post) do |builder|
+          concat(builder.input(:publish_at, :as => :datetime_picker, :required => true))
+        end)
+        output_buffer.should have_tag("input[@required]")
+      end
+    end
+  end
+  
+end

--- a/spec/inputs/placeholder_spec.rb
+++ b/spec/inputs/placeholder_spec.rb
@@ -16,7 +16,7 @@ describe 'string input' do
   
   describe "placeholder text" do
     
-    [:email, :number, :password, :phone, :search, :string, :url, :text].each do |type|
+    [:email, :number, :password, :phone, :search, :string, :url, :text, :date_picker, :time_picker, :datetime_picker].each do |type|
       
       describe "for #{type} inputs" do
         

--- a/spec/inputs/time_picker_input_spec.rb
+++ b/spec/inputs/time_picker_input_spec.rb
@@ -1,0 +1,455 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe 'time_picker input' do
+
+  include FormtasticSpecHelper
+
+  before do
+    @output_buffer = ''
+    mock_everything
+  end
+  
+  context "with an object" do
+    before do
+      concat(semantic_form_for(@new_post) do |builder|
+        concat(builder.input(:publish_at, :as => :time_picker))
+      end)
+    end
+    
+    it_should_have_input_wrapper_with_class(:time_picker)
+    it_should_have_input_wrapper_with_class(:input)
+    it_should_have_input_wrapper_with_class(:stringish)
+    it_should_have_input_wrapper_with_id("post_publish_at_input")
+    it_should_have_label_with_text(/Publish at/)
+    it_should_have_label_for("post_publish_at")
+    it_should_have_input_with_id("post_publish_at")
+    it_should_have_input_with_type(:time)
+    it_should_have_input_with_name("post[publish_at]")
+    it_should_apply_custom_input_attributes_when_input_html_provided(:date_picker)
+    it_should_apply_custom_for_to_label_when_input_html_id_provided(:date_picker)
+    # TODO why does this blow-up it_should_apply_error_logic_for_input_type(:date_picker)
+    
+  end
+  
+  describe "size attribute" do
+    
+    it "defaults to 5 chars (HH:MM)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker))
+        end
+      )
+      output_buffer.should have_tag "input[size='5']"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker, :input_html => { :size => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[size='11']"
+    end
+    
+    it "can be set from options (ignoring input_html)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker, :size => '12', :input_html => { :size => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[size='12']"
+    end
+
+  end
+
+  describe "maxlength attribute" do
+
+    it "defaults to 5 chars (HH:MM:SS)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker))
+        end
+      )
+      output_buffer.should have_tag "input[maxlength='5']"
+    end
+
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker, :input_html => { :maxlength => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[maxlength='11']"
+    end
+    
+    it "can be set from options (ignoring input_html)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker, :maxlength => 12, :input_html => { :maxlength => "11" }))
+        end
+      )
+      output_buffer.should have_tag "input[maxlength='12']"
+    end
+    
+  end
+  
+  describe "value attribute" do
+  
+    context "when method returns nil" do
+      
+      it "has no value" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker ))
+          end
+        )
+        output_buffer.should_not have_tag "li input[value]"
+      end
+      
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker, :input_html => { :value => "12:00" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='12:00']"
+      end
+      
+    end
+  
+    context "when method returns a Date" do
+      
+      before do
+        @date = Date.new(2000, 11, 11)
+        @new_post.stub!(:publish_at).and_return(@date)
+      end
+      
+      it "renders 00:00" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='00:00']"
+      end
+
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker, :input_html => { :value => "23:59" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='23:59']"
+      end
+      
+    end
+  
+    context "when method returns a Time" do
+    
+      before do
+        @time = Time.utc(2000,11,11,11,11,11)
+        @new_post.stub!(:publish_at).and_return(@time)
+      end
+      
+      it "renders the time as a HH:MM" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='11:11']"
+      end
+    
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker, :input_html => { :value => "12:12" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='12:12']"
+      end
+      
+    end
+  
+    context "when method returns an empty String" do
+      
+      before do
+        @new_post.stub!(:publish_at).and_return("")
+      end
+      
+      it "will be empty" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='']"
+      end
+      
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker, :input_html => { :value => "12:12:12" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='12:12:12']"
+      end
+      
+    end
+  
+    context "when method returns a String" do
+      
+      before do
+        @new_post.stub!(:publish_at).and_return("yeah")
+      end
+      
+      it "will be the string" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker ))
+          end
+        )
+        output_buffer.should have_tag "input[value='yeah']"
+      end
+    
+      it "can be set from :input_html options" do
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :time_picker, :input_html => { :value => "12:12:12" }))
+          end
+        )
+        output_buffer.should have_tag "input[value='12:12:12']"
+      end
+      
+    end
+
+  end
+  
+  describe "min attribute" do
+    
+    it "will be omitted by default" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker))
+        end
+      )
+      output_buffer.should_not have_tag "input[min]"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker, :input_html => { :min => "13:00" }))
+        end
+      )
+      output_buffer.should have_tag "input[min='13:00']"
+    end
+    
+  end
+  
+  describe "max attribute" do
+
+    it "will be omitted by default" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker))
+        end
+      )
+      output_buffer.should_not have_tag "input[max]"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker, :input_html => { :max => "13:00" }))
+        end
+      )
+      output_buffer.should have_tag "input[max='13:00']"
+    end
+    
+  end
+  
+  describe "step attribute" do
+    
+    it "defaults to 60 (seconds)" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker))
+        end
+      )
+      output_buffer.should have_tag "input[step='60']"
+    end
+
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker, :input_html => { :step => "3600" }))
+        end
+      )
+      output_buffer.should have_tag "input[step='3600']"
+    end
+    
+    describe "macros" do
+      before do 
+        concat(
+          semantic_form_for(@new_post) do |f|
+            concat(f.input(:publish_at, :as => :date_picker, :input_html => { :step => step }))
+          end
+        )
+      end
+      
+      context ":second" do
+        let(:step) { :second }
+        it "uses 1" do
+          output_buffer.should have_tag "input[step='1']"
+        end
+      end
+      
+      context ":minute" do
+        let(:step) { :minute }
+        it "uses 60" do
+          output_buffer.should have_tag "input[step='60']"
+        end
+      end
+      
+      context ":fifteen_minutes" do
+        let(:step) { :fifteen_minutes }
+        it "uses 900" do
+          output_buffer.should have_tag "input[step='900']"
+        end
+      end
+      
+      context ":quarter_hour" do
+        let(:step) { :quarter_hour }
+        it "uses 900" do
+          output_buffer.should have_tag "input[step='900']"
+        end
+      end
+      
+      context ":thirty_minutes" do
+        let(:step) { :thirty_minutes }
+        it "uses 1800" do
+          output_buffer.should have_tag "input[step='1800']"
+        end
+      end
+      
+      context ":half_hour" do
+        let(:step) { :half_hour }
+        it "uses 1800" do
+          output_buffer.should have_tag "input[step='1800']"
+        end
+      end
+      
+      context ":hour" do
+        let(:step) { :hour }
+        it "uses 3600" do
+          output_buffer.should have_tag "input[step='3600']"
+        end
+      end
+      
+      context ":sixty_minutes" do
+        let(:step) { :sixty_minutes }
+        it "uses 3600" do
+          output_buffer.should have_tag "input[step='3600']"
+        end
+      end
+      
+    end
+        
+  end
+  
+  describe "placeholder attribute" do
+    
+    it "will be omitted" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker))
+        end
+      )
+      output_buffer.should_not have_tag "input[placeholder]"
+    end
+    
+    it "can be set from :input_html options" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:publish_at, :as => :time_picker, :input_html => { :placeholder => "HH:MM" }))
+        end
+      )
+      output_buffer.should have_tag "input[placeholder='HH:MM']"
+    end
+    
+    context "with i18n set" do
+      before do
+        ::I18n.backend.store_translations :en, :formtastic => { :placeholders => { :publish_at => 'HH:MM' }}
+      end
+      
+      it "can be set with i18n" do
+        with_config :i18n_lookups_by_default, true do
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(:publish_at, :as => :time_picker))
+          end)
+          output_buffer.should have_tag('input[@placeholder="HH:MM"]')
+        end
+      end
+      
+      it "can be set with input_html, trumping i18n" do
+        with_config :i18n_lookups_by_default, true do
+          concat(semantic_form_for(@new_post) do |builder|
+            concat(builder.input(:publish_at, :as => :time_picker, :input_html => { :placeholder => "Something" }))
+          end)
+          output_buffer.should have_tag('input[@placeholder="Something"]')
+        end
+      end
+    end
+    
+  end
+  
+  describe "when namespace is provided" do
+    before do
+      concat(semantic_form_for(@new_post, :namespace => "context2") do |builder|
+        concat(builder.input(:publish_at, :as => :time_picker))
+      end)
+    end
+
+    it_should_have_input_wrapper_with_id("context2_post_publish_at_input")
+    it_should_have_label_and_input_with_id("context2_post_publish_at")
+  end
+  
+  describe "when index is provided" do
+    before do
+      @output_buffer = ''
+      mock_everything
+
+      concat(semantic_form_for(@new_post) do |builder|
+        concat(builder.fields_for(:author, :index => 3) do |author|
+          concat(author.input(:created_at, :as => :time_picker))
+        end)
+      end)
+    end
+    
+    it 'should index the id of the wrapper' do
+      output_buffer.should have_tag("li#post_author_attributes_3_created_at_input")
+    end
+    
+    it 'should index the id of the select tag' do
+      output_buffer.should have_tag("input#post_author_attributes_3_created_at")
+    end
+    
+    it 'should index the name of the select tag' do
+      output_buffer.should have_tag("input[@name='post[author_attributes][3][created_at]']")
+    end
+  end
+  
+  describe "when required" do
+    it "should add the required attribute to the input's html options" do
+      with_config :use_required_attribute, true do 
+        concat(semantic_form_for(@new_post) do |builder|
+          concat(builder.input(:publish_at, :as => :time_picker, :required => true))
+        end)
+        output_buffer.should have_tag("input[@required]")
+      end
+    end
+  end
+  
+end


### PR DESCRIPTION
```
:as => :date_picker
:as => :time_picker
:as => :datetime_picker
:as => :datetime_picker, :local => false
```

Does not include any extra CSS or JS for rendering non-native calendar widgets (and won't!). Some browsers already have support, others can be polyfilled with the UI and JS libraries of your choice.
