### PR TITLE
Remove custom_inline_order configuration and mention in initializer template since its no longer used

### DIFF
--- a/lib/formtastic/form_builder.rb
+++ b/lib/formtastic/form_builder.rb
@@ -18,7 +18,6 @@ module Formtastic
     configure :label_str_method, :humanize
     configure :collection_label_methods, %w[to_label display_name full_name name title username login value to_s]
     configure :collection_value_methods, %w[id to_s]
-    configure :custom_inline_order, {}
     configure :file_methods, [ :file?, :public_filename, :filename ]
     configure :file_metadata_suffixes, ['content_type', 'file_name', 'file_size']
     configure :priority_countries, ["Australia", "Canada", "United Kingdom", "United States"]

--- a/lib/generators/templates/formtastic.rb
+++ b/lib/generators/templates/formtastic.rb
@@ -49,12 +49,6 @@
 # Formtastic::FormBuilder.collection_label_methods = [
 #   "to_label", "display_name", "full_name", "name", "title", "username", "login", "value", "to_s"]
 
-# Additionally, you can customize the order for specific types of inputs.
-# This is configured on a type basis and if a type is not found it will
-# fall back to the default order as defined by #inline_order
-# Formtastic::FormBuilder.custom_inline_order[:checkbox] = [:errors, :hints, :input]
-# Formtastic::FormBuilder.custom_inline_order[:select] = [:hints, :input, :errors]
-
 # Specifies if labels/hints for input fields automatically be looked up using I18n.
 # Default value: true. Overridden for specific fields by setting value to true,
 # i.e. :label => true, or :hint => true (or opposite depending on initialized value)


### PR DESCRIPTION
I noticed the `inline_order` config option was removed in favor of overriding `input_wrapping` or creating a new input class, but it was still mentioned in the initializer and the `custom_inline_order` config option was still defined.
