### PR TITLE
Add CSS class to select fragments for time elements

### DIFF
--- a/lib/formtastic/inputs/base/timeish.rb
+++ b/lib/formtastic/inputs/base/timeish.rb
@@ -157,7 +157,7 @@ module Formtastic
         
         def fragment_input_html(fragment)
           opts = input_options.merge(:prefix => fragment_prefix, :field_name => fragment_name(fragment), :default => value, :include_blank => include_blank?)
-          template.send(:"select_#{fragment}", value, opts, input_html_options.merge(:id => fragment_id(fragment)))
+          template.send(:"select_#{fragment}", value, opts, input_html_options.merge(:id => fragment_id(fragment), :class => "input_#{fragment_label(fragment).downcase}" ))
         end
         
         def fragment_prefix


### PR DESCRIPTION
Appropriate CSS classes help provide hooks for styling and JS
e.g. instead of having to refer to the day, month, year selects
by their nth-child ordering, we can do .input_day and .input_month
