### PR TITLE
include validations on ancestors

### DIFF
--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -23,9 +23,10 @@ module Formtastic
 
         def validations
           @validations ||= if object && object.class.respond_to?(:validators_on)
-            object.class.validators_on(attributized_method_name).select do |validator|
-              validator_relevant?(validator)
-            end
+            object.class.ancestors.
+              select { |ancestor| ancestor.respond_to?(:validators_on) }.
+              inject([]) { |validators, ancestor| validators + ancestor.validators_on(attributized_method_name) }.
+              select { |validator| validator_relevant?(validator) }
           else
             nil
           end


### PR DESCRIPTION
Hi

Validations on parent classes were not taken into accout. I mean, if we have

```
class Post < ActiveRecord::Base
  validates :title, :presence => true
end

class SpecialPost < Post
end

semantic_form_for SpecialPost.new do |f|
  f.input :title
end
```

Then the label for title would not include an asterisk, meaning this field is required (and it should)

This pull request fixes that

Thanks!
