### PR TITLE
Coerce `method` into a `Symbol` if it's a `String` 

### DIFF
--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -232,6 +232,7 @@ module Formtastic
       # @todo Many many more examples. Some of the detail probably needs to be pushed out to the relevant methods too.
       # @todo More i18n examples.
       def input(method, options = {})
+        method = method.to_sym if method.is_a?(String)
         options = options.dup # Allow options to be shared without being tainted by Formtastic
         options[:as] ||= default_input_type(method, options)
 

--- a/spec/inputs/label_spec.rb
+++ b/spec/inputs/label_spec.rb
@@ -38,6 +38,16 @@ describe 'Formtastic::FormBuilder#label' do
     end)
     output_buffer.should have_tag('label', /Title/)
   end
+  
+  it 'should use i18n instead of the method name when method given as a String' do
+    with_config :i18n_cache_lookups, true do
+      ::I18n.backend.store_translations :en, { :formtastic => { :labels => { :post => { :title => "I18n title" } } } }
+      concat(semantic_form_for(@new_post) do |builder|
+        builder.input("title")
+      end)
+      output_buffer.should have_tag('label', /I18n title/)
+    end
+  end
 
   it 'should humanize the given attribute for date fields' do
     concat(semantic_form_for(@new_post) do |builder|


### PR DESCRIPTION
See #838
