### PR TITLE
use_required_attribute/perform_browser_validations initializer documentation fix

### DIFF
--- a/lib/generators/templates/formtastic.rb
+++ b/lib/generators/templates/formtastic.rb
@@ -67,10 +67,10 @@
 # Formtastic::Helpers::FormHelper.builder = MyCustomBuilder
 
 # You can opt-in to Formtastic's use of the HTML5 `required` attribute on `<input>`, `<select>` 
-# and `<textarea>` tags by setting this to false (defaults to true).
-# Formtastic::FormBuilder.use_required_attribute = true
+# and `<textarea>` tags by setting this to true (defaults to false).
+# Formtastic::FormBuilder.use_required_attribute = false
 
 # You can opt-in to new HTML5 browser validations (for things like email and url inputs) by setting
-# this to false. Doing so will add a `novalidate` attribute to the `<form>` tag.
+# this to true. Doing so will add a `novalidate` attribute to the `<form>` tag.
 # See http://diveintohtml5.org/forms.html#validation for more info.
 # Formtastic::FormBuilder.perform_browser_validations = true


### PR DESCRIPTION
Currently, the documentation in the generated initializer states that you can opt-in by setting the following to false, which seems to be wrong:

``` ruby
# Formtastic::FormBuilder.use_required_attribute = true
# Formtastic::FormBuilder.perform_browser_validations = true
```

I fixed that in the commit.
