### PR TITLE
cleanup Labelling#label_html_options

### DIFF
--- a/lib/formtastic/inputs/base/labelling.rb
+++ b/lib/formtastic/inputs/base/labelling.rb
@@ -10,13 +10,10 @@ module Formtastic
         end
         
         def label_html_options
-          # opts = options_for_label(options) # TODO
-          opts = {}
-          opts[:for] ||= input_html_options[:id]
-          opts[:class] = [opts[:class]]
-          opts[:class] << 'label'
-          
-          opts
+          {
+            :for => input_html_options[:id],
+            :class => ['label'],
+          }
         end
         
         def label_text


### PR DESCRIPTION
`Labelling#label_html_options` has some rather strange and unnecessary logic just to spit out a hash. Cleaned up.
