### PR TITLE
Regarding comments on 7f612bb

### DIFF
--- a/app/assets/stylesheets/formtastic.css
+++ b/app/assets/stylesheets/formtastic.css
@@ -194,7 +194,8 @@ This stylesheet forms part of the Formtastic Rails Plugin
   width:72%;
 }
 
-.formtastic .stringish input[size] {
+.formtastic .stringish input[size],
+.formtastic .stringish input[max] {
   width:auto;
   max-width:72%;
 }


### PR DESCRIPTION
Adding `.formtastic .stringish input[max]` into formtastic.css to line 197 would be enough to prevent number inputs from stretching full width as other .stringish without size attribute.
