### PR TITLE
Fix HTML syntax in sample file

### DIFF
--- a/sample/basic_inputs.html
+++ b/sample/basic_inputs.html
@@ -215,7 +215,7 @@
           <button id="gem_submit" type="reset">Reset</button>
         </li>
         <li class="action link_action">
-          <a href="#">Cancel</button>
+          <a href="#">Cancel</a>
         </li>
       </ol>
     </fieldset>


### PR DESCRIPTION
This fixes a typo in the sample/basic_inputs.html file. 
