### PR TITLE
Make sure checkbox values with integers are checked

### DIFF
--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -113,7 +113,7 @@ module Formtastic
         # Avoids an issue where `send_or_call` can be a String and duck can be something simple like
         # `:first`, which obviously String responds to.
         def send_or_call_or_object(duck, object)
-          return object if object.is_a?(String) # TODO what about other classes etc?
+          return object if object.is_a?(String) || object.is_a?(Integer) # TODO what about other classes etc?
           send_or_call(duck, object)
         end
 

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -441,7 +441,21 @@ describe 'check_boxes input' do
 
     it "should not check any items" do
       output_buffer.should have_tag('form li input[@checked]', :count => 0)
-    end    
+    end
+
+    describe "and the attribute has values" do
+      before do
+        @fred.stub(:posts) { [1] }
+
+        concat(semantic_form_for(@fred) do |builder|
+          concat(builder.input(:posts, :as => :check_boxes, :collection => @_collection))
+        end)
+      end
+
+      it "should check the appropriate items" do
+        output_buffer.should have_tag("form li input[@value='1'][@checked]")
+      end
+    end
   end
   
 end


### PR DESCRIPTION
See issue #860.

This commit fixes check boxes w/collection with integer keys. Check boxes are now properly marked as checked.
