### PR TITLE
ensure reference to Rails is always prefixed with ::

### DIFF
--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -321,7 +321,7 @@ module Formtastic
       def input_class(as)
         @input_classes_cache ||= {}
         @input_classes_cache[as] ||= begin
-          Rails.application.config.cache_classes ? input_class_with_const_defined(as) : input_class_by_trying(as)
+          ::Rails.application.config.cache_classes ? input_class_with_const_defined(as) : input_class_by_trying(as)
         end
       end
       

--- a/lib/generators/formtastic/form/form_generator.rb
+++ b/lib/generators/formtastic/form/form_generator.rb
@@ -14,7 +14,7 @@ module Formtastic
   #   $ rails generate formtastic:form Post title:string body:text
   # @example Generate a form for a specific controller
   #   $ rails generate formtastic:form Post --controller admin/posts
-  class FormGenerator < Rails::Generators::NamedBase
+  class FormGenerator < ::Rails::Generators::NamedBase
     desc "Generates a Formtastic form partial based on an existing model."
 
     argument :name, :type => :string, :required => true, :banner => 'MODEL_NAME'

--- a/lib/generators/formtastic/install/install_generator.rb
+++ b/lib/generators/formtastic/install/install_generator.rb
@@ -8,7 +8,7 @@ module Formtastic
   #   $ rails generate formtastic:install
   #
   # @todo Test with Rails 3.0
-  class InstallGenerator < Rails::Generators::Base
+  class InstallGenerator < ::Rails::Generators::Base
     source_root File.expand_path('../../../templates', __FILE__)
     class_option :template_engine
 

--- a/spec/inputs/custom_input_spec.rb
+++ b/spec/inputs/custom_input_spec.rb
@@ -11,7 +11,7 @@ module TestInputs
     @method = :title
     @options = {}
     @proc = Proc.new {}
-    if Rails::VERSION::MAJOR == 4
+    if ::Rails::VERSION::MAJOR == 4
       @builder = Formtastic::FormBuilder.new(@object_name, @object, @template, @options)
     else
       @builder = Formtastic::FormBuilder.new(@object_name, @object, @template, @options, @proc)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -432,7 +432,7 @@ module FormtasticSpecHelper
     # In edge rails (Rails 4) tags store method_name as a string and index the errors object using a string
     # therefore allow stubs to match on either string or symbol.  The errors object calls to_sym on all index 
     # accesses so @object.errors[:abc] is equivalent to @object.errors["abc"]
-    if Rails::VERSION::MAJOR == 4
+    if ::Rails::VERSION::MAJOR == 4
       ToSMatcher.new(method)
     else
       method

--- a/spec/support/test_environment.rb
+++ b/spec/support/test_environment.rb
@@ -13,7 +13,7 @@ require 'active_model'
 
 # Create a simple rails application for use in testing the viewhelper
 module FormtasticTest
-  class Application < Rails::Application
+  class Application < ::Rails::Application
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
     config.active_support.deprecation = :stderr


### PR DESCRIPTION
Fixed problem with formtastic-bootstrap gem, in trying to make it work with formtastic 2.2.
