### PR TITLE
make the input method can accept a block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Gemfile.lock
 doc/
 tmp
 gemfiles/*.lock
+tags

--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -236,6 +236,10 @@ module Formtastic
         options = options.dup # Allow options to be shared without being tainted by Formtastic
         options[:as] ||= default_input_type(method, options)
 
+        if block_given?
+          options[:block_content] = template.capture(&block)
+        end
+
         klass = input_class(options[:as])
 
         klass.new(self, template, @object, @object_name, method, options).to_html

--- a/lib/formtastic/inputs/base/wrapping.rb
+++ b/lib/formtastic/inputs/base/wrapping.rb
@@ -8,7 +8,7 @@ module Formtastic
         # errors before the body of the input).
         def input_wrapping(&block)
           template.content_tag(:li, 
-            [template.capture(&block), error_html, hint_html].join("\n").html_safe, 
+            [template.capture(&block), options[:block_content], error_html, hint_html].join("\n").html_safe, 
             wrapper_html_options
           )
         end


### PR DESCRIPTION
Sometimes I need to add something other into the input wrapper `<li>`,  so it can be convenient  if the input can be called  with a block, and the block code is inserted after the input in the page .
