### PR TITLE
Added possibility to manually decide whether a check box is checked

### DIFF
--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -101,7 +101,9 @@ module Formtastic
       end
 
       def checked?
-        if defined? ActionView::Helpers::InstanceTag
+        if input_html_options.key?(:checked)
+          input_html_options[:checked]
+        elsif defined? ActionView::Helpers::InstanceTag
           object && ActionView::Helpers::InstanceTag.check_box_checked?(object.send(method), checked_value)
         else
           object && boolean_checked?(object.send(method), checked_value) 

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -41,6 +41,22 @@ describe 'boolean input' do
     output_buffer.should have_tag('form li label input[@type="checkbox"][@value="1"]')
   end
 
+  it 'should generate a checked input if :input_html => { :checked => true } is passed' do
+    @output_buffer = ''
+    concat(semantic_form_for(@new_post) do |builder|
+      concat(builder.input(:answer_comments, :as => :boolean, :input_html => {:checked => true}))
+    end)
+    output_buffer.should have_tag('form li label input[@checked="checked"]')
+  end
+
+  it 'should not generate a checked input if :input_html => { :checked => false } is passed' do
+    @output_buffer = ''
+    concat(semantic_form_for(@new_post) do |builder|
+      concat(builder.input(:answer_comments, :as => :boolean, :input_html => {:checked => false}))
+    end)
+    output_buffer.should_not have_tag('form li label input[@checked="checked"]')
+  end
+
   it 'should generate a checked input if object.method returns true' do
     output_buffer.should have_tag('form li label input[@checked="checked"]')
     output_buffer.should have_tag('form li input[@name="post[allow_comments]"]', :count => 2)


### PR DESCRIPTION
I wanted the possibility to decide whether a check box is checked or not by passing the corresponding value (true or false) to the input. This now can be done by passing :input_html => { :checked => true/false }. Previously you only could check the input but not _uncheck_ it, e.g. when builder.object.send(:method) returns true and you want the corresponding check box unchecked

I hope that helps.

Jan
