### PR TITLE
Don't use ActionView::Helpers::InstanceTag.check_box_checked? anymore

### DIFF
--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -97,11 +97,7 @@ module Formtastic
       end
 
       def checked?
-        if defined? ActionView::Helpers::InstanceTag
-          object && ActionView::Helpers::InstanceTag.check_box_checked?(object.send(method), checked_value)
-        else
-          object && boolean_checked?(object.send(method), checked_value) 
-        end
+        object && boolean_checked?(object.send(method), checked_value) 
       end
       
       private 


### PR DESCRIPTION
Even though ActionView::Helpers::InstanceTag exists in Rails 4, the check_box_checked? method is gone, so the defined? check that was put in earlier did not have the desired effect.

I propose to always use our own boolean_checked? method since that works across all Rails versions.

This fixes the rendering of check boxes in Rails 4 (edge Rails).
