### PR TITLE
Upgrade RSpec to 2.12.x

### DIFF
--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<actionpack>, [">= 3.0"])
 
-  s.add_development_dependency(%q<rspec-rails>, ["~> 2.8.0"])
+  s.add_development_dependency(%q<rspec-rails>, ["~> 2.12.0"])
   s.add_development_dependency(%q<rspec_tag_matchers>, [">= 1.0.0"])
   s.add_development_dependency(%q<hpricot>, ["~> 0.8.3"])
   s.add_development_dependency(%q<BlueCloth>) # for YARD


### PR DESCRIPTION
- it supports stubbing constants, expects { }, etc.
