### PR TITLE
Fix bug with Rails 4 multiselect

### DIFF
--- a/lib/formtastic/inputs/select_input.rb
+++ b/lib/formtastic/inputs/select_input.rb
@@ -198,7 +198,7 @@ module Formtastic
       def extra_input_html_options
         {
           :multiple => multiple?,
-          :name => (multiple? && Rails::VERSION::MAJOR == 3) ? input_html_options_name_multiple : input_html_options_name
+          :name => (multiple? && Rails::VERSION::MAJOR >= 3) ? input_html_options_name_multiple : input_html_options_name
         }
         
         


### PR DESCRIPTION
Formtastic incorrectly naming the input field for non-association based selects.  Change a strict `==`  for Rails version being 3.
