### PR TITLE
Allow for html options within check_box collection

### DIFF
--- a/lib/formtastic/inputs/check_boxes_input.rb
+++ b/lib/formtastic/inputs/check_boxes_input.rb
@@ -44,6 +44,7 @@ module Formtastic
     #   <%= f.input :categories, :as => :check_boxes, :collection => [["Ruby", "ruby"], ["Rails", "rails"]] %>
     #   <%= f.input :categories, :as => :check_boxes, :collection => [["Ruby", "1"], ["Rails", "2"]] %>
     #   <%= f.input :categories, :as => :check_boxes, :collection => [["Ruby", 1], ["Rails", 2]] %>
+    #   <%= f.input :categories, :as => :check_boxes, :collection => [["Ruby", 1, {'data-attr' => 'attr-value'}]] %>
     #   <%= f.input :categories, :as => :check_boxes, :collection => 1..5 %>
     #
     # @example `:hidden_fields` can be used to skip Rails' rendering of a hidden field before every checkbox
@@ -127,7 +128,7 @@ module Formtastic
         value = choice_value(choice)
         builder.check_box(
           association_primary_key || method,
-          input_html_options.merge(:id => choice_input_dom_id(choice), :name => input_name, :disabled => disabled?(value), :required => false),
+          extra_html_options(choice).merge(:id => choice_input_dom_id(choice), :name => input_name, :disabled => disabled?(value), :required => false),
           value,
           unchecked_value
         )
@@ -139,8 +140,12 @@ module Formtastic
           input_name,
           value,
           checked?(value),
-          input_html_options.merge(:id => choice_input_dom_id(choice), :disabled => disabled?(value), :required => false)
+          extra_html_options(choice).merge(:id => choice_input_dom_id(choice), :disabled => disabled?(value), :required => false)
         )
+      end
+
+      def extra_html_options(choice)
+        input_html_options.merge(custom_choice_html_options(choice))
       end
 
       def checked?(value)

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -456,6 +456,22 @@ describe 'check_boxes input' do
         output_buffer.should have_tag("form li input[@value='1'][@checked]")
       end
     end
+
+    describe "and the collection includes html options" do
+      before do
+        @_collection = [["First", 1, {'data-test' => 'test-data'}], ["Second", 2, {'data-test2' => 'test-data2'}]]
+
+        concat(semantic_form_for(@fred) do |builder|
+          concat(builder.input(:posts, :as => :check_boxes, :collection => @_collection))
+        end)
+      end
+
+      it "should have injected the html attributes" do
+        @_collection.each do |v|
+          output_buffer.should have_tag("form li input[@value='#{v[1]}'][@#{v[2].keys[0]}='#{v[2].values[0]}']")
+        end
+      end
+    end
   end
   
 end


### PR DESCRIPTION
I wanted to be able to create custom data properties in my checkboxes. I added this to work in a similar way as the select input.

Thanks!
