### PR TITLE
allow a proc to be given as label option

### DIFF
--- a/lib/formtastic/localizer.rb
+++ b/lib/formtastic/localizer.rb
@@ -61,6 +61,8 @@ module Formtastic
       
       if value.is_a?(::String)
         escape_html_entities(value)
+      elsif value.is_a?(::Proc)# allow a proc to be given as label option
+        value.call(key)
       else
         use_i18n = value.nil? ? i18n_lookups_by_default : (value != false)
         use_cache = i18n_cache_lookups

--- a/spec/inputs/label_spec.rb
+++ b/spec/inputs/label_spec.rb
@@ -139,6 +139,13 @@ describe 'Formtastic::FormBuilder#label' do
       output_buffer.should have_tag('label b')
     end
 
+    it 'should allow a proc to be given as label option' do
+      concat(semantic_form_for(@new_post) do |builder|
+        builder.input(:title, :label => proc{ 'My label' })
+      end)
+      output_buffer.should have_tag('label', /My label/)
+    end
+
   end
 
 end


### PR DESCRIPTION
allow a proc to be given as label option, for example:

```
semantic_form_for(@new_post) do |builder|
  builder.input(:title, :label => proc{ 'My label' })
end
```

see details: https://github.com/justinfrench/formtastic/issues/888
