### PR TITLE
Remove deprecation warnings for .scoped

### DIFF
--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -86,15 +86,15 @@ module Formtastic
             scope_conditions = conditions_from_reflection.empty? ? nil : {:conditions => conditions_from_reflection}
             if conditions_from_options.any?
               if Util.rails3?
-                reflection.klass.scoped(scope_conditions).where(conditions_from_options)
+                reflection.klass.all(scope_conditions).where(conditions_from_options)
               else
                 reflection.klass.where(scope_conditions[:conditions]).where(conditions_from_options)
               end
             else
-              
+
               if Util.rails3?
                 find_options_from_options.merge!(:include => group_by) if self.respond_to?(:group_by) && group_by
-                reflection.klass.scoped(scope_conditions).where(find_options_from_options)
+                reflection.klass.all(scope_conditions).where(find_options_from_options)
               else
                 coll = reflection.klass.where(scope_conditions)
                 coll = coll.includes(group_by) if self.respond_to?(:group_by) && group_by

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -163,7 +163,7 @@ describe 'select input' do
     it 'should not create a multi-select' do
       output_buffer.should_not have_tag('form li select[@multiple]')
     end
-    
+
     it 'should not add a hidden input' do
       output_buffer.should_not have_tag('form li input[@type="hidden"]')
     end
@@ -226,7 +226,7 @@ describe 'select input' do
 
     it "should call author.find with association conditions" do
       if Formtastic::Util.rails3?
-        ::Author.should_receive(:scoped).with(:conditions => {:active => true})
+        ::Author.should_receive(:all).with(:conditions => {:active => true})
       else
         ::Author.should_receive(:where).with(:conditions => {:active => true})
       end
@@ -238,14 +238,14 @@ describe 'select input' do
 
     it "should call author.find with association conditions and find_options conditions" do
       if Formtastic::Util.rails3?
-        ::Author.should_receive(:scoped).with(:conditions => {:active => true})
+        ::Author.should_receive(:all).with(:conditions => {:active => true})
         ::Author.should_receive(:where).with({:publisher => true})
       else
         proxy = stub
         ::Author.should_receive(:where).with({:active => true}).and_return(proxy)
         proxy.should_receive(:where).with({:publisher => true})
       end
-      
+
 
       with_deprecation_silenced do
         semantic_form_for(@new_post) do |builder|
@@ -326,7 +326,7 @@ describe 'select input' do
        proxy.should_receive(:includes).with(:continent).and_call_original
       end
 
-      with_deprecation_silenced do 
+      with_deprecation_silenced do
         semantic_form_for(@new_post) do |builder|
           concat(builder.input(:author, :as => :select, :group_by => :continent ) )
         end
@@ -357,7 +357,7 @@ describe 'select input' do
     it 'should have a multi-select select' do
       output_buffer.should have_tag('form li select[@multiple="multiple"]')
     end
-    
+
     it 'should append [] to the name attribute for multiple select' do
       output_buffer.should have_tag('form li select[@multiple="multiple"][@name="author[post_ids][]"]')
     end
@@ -594,32 +594,32 @@ describe 'select input' do
     it_should_have_select_with_id("context2_post_author_ids")
     it_should_have_label_for("context2_post_author_ids")
   end
-  
+
   describe "when index is provided" do
-  
+
     before do
       @output_buffer = ''
       mock_everything
-  
+
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.fields_for(:author, :index => 3) do |author|
           concat(author.input(:name, :as => :select))
         end)
       end)
     end
-    
+
     it 'should index the id of the wrapper' do
       output_buffer.should have_tag("li#post_author_attributes_3_name_input")
     end
-    
+
     it 'should index the id of the select tag' do
       output_buffer.should have_tag("select#post_author_attributes_3_name")
     end
-    
+
     it 'should index the name of the select' do
       output_buffer.should have_tag("select[@name='post[author_attributes][3][name]']")
     end
-    
+
   end
 
   context "when required" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,10 +36,10 @@ module FormtasticSpecHelper
   include ActionView::Helpers::AssetTagHelper
   include ActiveSupport
   include ActionController::PolymorphicRoutes if defined?(ActionController::PolymorphicRoutes)
-  include ActionDispatch::Routing::PolymorphicRoutes 
+  include ActionDispatch::Routing::PolymorphicRoutes
   include AbstractController::UrlFor if defined?(AbstractController::UrlFor)
   include ActionView::RecordIdentifier if defined?(ActionView::RecordIdentifier)
-  
+
   include Formtastic::Helpers::FormHelper
 
   def default_input_type(column_type, column_name = :generic_column_name)
@@ -151,50 +151,50 @@ module FormtasticSpecHelper
       sym == :options ? false : super
     end
   end
-  
+
   # In Rails 3 Model.all returns an array. In Rails 4, it returns an
-  # association proxy, which quacks a lot like an array. We use this in stubs 
+  # association proxy, which quacks a lot like an array. We use this in stubs
   # or mocks where we need to return the later.
-  # 
+  #
   # TODO try delegate?
   # delegate :map, :size, :length, :first, :to_ary, :each, :include?, :to => :array
   class MockScope
     attr_reader :array
-    
+
     def initialize(the_array)
       @array = the_array
     end
-    
+
     def map(&block)
       array.map(&block)
     end
-    
+
     def where(*args)
       # array
       self
     end
-    
+
     def includes(*args)
       self
     end
-    
+
     def size
       array.size
     end
     alias_method :length, :size
-    
+
     def first
       array.first
     end
-    
+
     def to_ary
       array
     end
-    
+
     def each(&block)
       array.each(&block)
     end
-    
+
     def include?(*args)
       array.include?(*args)
     end
@@ -236,8 +236,8 @@ module FormtasticSpecHelper
     def author_path(*args); "/authors/1"; end
     def authors_path(*args); "/authors"; end
     def new_author_path(*args); "/authors/new"; end
-    
-    # Returns the array for Rails 3 and a thing that looks looks like an 
+
+    # Returns the array for Rails 3 and a thing that looks looks like an
     # association proxy for Rails 4+
     def author_array_or_scope(the_array = [@fred, @bob])
       if ::Formtastic::Util.rails3?
@@ -246,7 +246,7 @@ module FormtasticSpecHelper
         MockScope.new(the_array)
       end
     end
-    
+
     @fred = ::Author.new
     @fred.stub!(:class).and_return(::Author)
     @fred.stub!(:to_label).and_return('Fred Smith')
@@ -286,8 +286,6 @@ module FormtasticSpecHelper
     @james.stub!(:persisted?).and_return(nil)
     @james.stub!(:name).and_return('James')
 
-
-    ::Author.stub!(:scoped).and_return(::Author)
     ::Author.stub!(:find).and_return(author_array_or_scope)
     ::Author.stub!(:all).and_return(author_array_or_scope)
     ::Author.stub!(:where).and_return(author_array_or_scope)
@@ -334,7 +332,7 @@ module FormtasticSpecHelper
     @fred.stub!(:posts).and_return(author_array_or_scope([@freds_post]))
     @fred.stub!(:post_ids).and_return([@freds_post.id])
 
-    ::Post.stub!(:scoped).and_return(::Post)
+    ::Post.stub!(:all).and_return(::Post)
     ::Post.stub!(:human_attribute_name).and_return { |column_name| column_name.humanize }
     ::Post.stub!(:human_name).and_return('Post')
     ::Post.stub!(:reflect_on_all_validations).and_return([])
@@ -474,24 +472,24 @@ module FormtasticSpecHelper
     yield
     Formtastic::FormBuilder.send(:"#{config_method_name}=", old_value)
   end
-  
+
   class ToSMatcher
     def initialize(str)
       @str=str.to_s
     end
-    
+
     def matches?(value)
       value.to_s==@str
     end
-    
+
     def failure_message_for_should
       "Expected argument that converted to #{@str}"
     end
   end
-  
+
   def errors_matcher(method)
     # In edge rails (Rails 4) tags store method_name as a string and index the errors object using a string
-    # therefore allow stubs to match on either string or symbol.  The errors object calls to_sym on all index 
+    # therefore allow stubs to match on either string or symbol.  The errors object calls to_sym on all index
     # accesses so @object.errors[:abc] is equivalent to @object.errors["abc"]
     if Rails::VERSION::MAJOR == 4
       ToSMatcher.new(method)
@@ -505,13 +503,13 @@ end
 
 RSpec.configure do |config|
   config.before(:each) do
-    Formtastic::Localizer.cache.clear!    
+    Formtastic::Localizer.cache.clear!
   end
-  
+
   config.before(:all) do
     DeferredGarbageCollection.start unless ENV["DEFER_GC"] == "false"
   end
   config.after(:all) do
-    DeferredGarbageCollection.reconsider unless ENV["DEFER_GC"] == "false"    
+    DeferredGarbageCollection.reconsider unless ENV["DEFER_GC"] == "false"
   end
 end


### PR DESCRIPTION
- Use .all since .scoped is deprecated in Rails 4
- Also get rid of whitespace since my editor asked nicely
