### PR TITLE
Allows to disable model infered class from form

### DIFF
--- a/lib/generators/templates/formtastic.rb
+++ b/lib/generators/templates/formtastic.rb
@@ -66,9 +66,19 @@
 # specifying that class here.  Defaults to Formtastic::FormBuilder.
 # Formtastic::Helpers::FormHelper.builder = MyCustomBuilder
 
-# If you don't want Formtastic to try to guess a class for the model and add it to the form, you can disable
-# it. Defaults to true.
-# Formtastic::Helpers::FormHelper.add_model_class_name_to_form_classes = false
+# All formtastic forms have a class that indicates that they are just that. You
+# can change it to any class you want.
+# Formtastic::Helpers::FormHelper.default_form_class = 'formtastic'
+
+# Formtastic will infer a class name from the model, array, string ot symbol you pass to the
+# form builder. You can customize the way that class is presented by overriding
+# this proc.
+# Formtastic::Helpers::FormHelper.default_form_model_class_proc = proc { |model_class_name| model_class_name }
+
+# Allows to set a custom field_error_proc wrapper. By default this wrapper
+# is disabled since `formtastic` already adds an error class to the LI tag
+# containing the input.
+# Formtastic::Helpers::FormHelper.formtastic_field_error_proc = proc { |html_tag, instance_tag| html_tag }
 
 # You can opt-in to Formtastic's use of the HTML5 `required` attribute on `<input>`, `<select>`
 # and `<textarea>` tags by setting this to true (defaults to false).

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -102,11 +102,15 @@ describe 'FormHelper' do
       output_buffer.should have_tag("form.namespaced_post")
     end
 
-    it 'omits the model class from the form classes' do
-      Formtastic::Helpers::FormHelper.add_model_class_name_to_form_classes = false
-      concat(semantic_form_for(@new_post) do |builder|
+    it 'adds a customized class to the generated form' do
+      Formtastic::Helpers::FormHelper.default_form_model_class_proc = lambda { |model_class_name| "#{model_class_name}_form" }
+      concat(semantic_form_for(@new_post, :url => '/hello') do |builder|
       end)
-      output_buffer.should have_tag("form[class='']")
+      output_buffer.should have_tag("form.post_form")
+
+      concat(semantic_form_for(:project, :url => '/hello') do |builder|
+      end)
+      output_buffer.should have_tag("form.project_form")
     end
 
     describe 'allows :html options' do


### PR DESCRIPTION
I found no other way of removing this class from the form, and I really don't want it there.

If there's another way of doing it that does not involve adding another config, I'd be glad to hear it.

Thanks.
