### PR TITLE
Sometimes you need to invert boolean field so you need to use 0 as a che...

### DIFF
--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -112,9 +112,7 @@ module Formtastic
           value
         when NilClass
           false
-        when Integer
-          value != 0
-        when String
+        when Integer, String
           value == checked_value
         when Array
           value.include?(checked_value)


### PR DESCRIPTION
Sometimes you need to invert meaning of boolean attribute on a form, for example display model.enabled attribute as "Disable" checkbox. To do this you need to invert the meaning of an attribute. You can do it by setting 

  checked_value: 0, unchecked_value: 1 

but unfortunately current version of formtastic would not work becaus 0 is hardcoded in boolean_checked? method for integer values.
