### PR TITLE
Add license information to gemspec

### DIFF
--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = %q{http://github.com/justinfrench/formtastic}
   s.summary     = %q{A Rails form builder plugin/gem with semantically rich and accessible markup}
   s.description = %q{A Rails form builder plugin/gem with semantically rich and accessible markup}
+  s.license     = 'MIT'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This increases the discoverability of what license this gem uses. See rubygems/rubygems.org#363 or [this blog post](http://www.benjaminfleischer.com/2013/07/12/make-the-world-a-better-place-put-a-license-in-your-gemspec/) for more info.
