### PR TITLE
Add docs badge to README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,6 +1,6 @@
 h1. Formtastic
 
-!https://travis-ci.org/justinfrench/formtastic.png?branch=master!:https://travis-ci.org/justinfrench/formtastic
+!https://travis-ci.org/justinfrench/formtastic.png?branch=master!:https://travis-ci.org/justinfrench/formtastic !http://inch-pages.github.io/github/justinfrench/formtastic.png!:http://inch-pages.github.io/github/justinfrench/formtastic/
 
 Formtastic is a Rails FormBuilder DSL (with some other goodies) to make it far easier to create beautiful, semantically rich, syntactically awesome, readily stylable and wonderfully accessible HTML forms in your Rails applications.
 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/justinfrench/formtastic.png)](http://inch-pages.github.io/github/justinfrench/formtastic)

It links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Formtastic is http://inch-pages.github.io/github/justinfrench/formtastic/

Inch Pages is still in it's infancy, but already used by projects like [Reek](https://github.com/troessner/reek) and [libnotify](https://github.com/splattael/libnotify).

What do you think?
