### PR TITLE
Fix `config/locale` path in README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -403,7 +403,7 @@ Formtastic supports localized *labels*, *hints*, *legends*, *actions* using the 
   Formtastic::FormBuilder.i18n_lookups_by_default = true
 </pre>
 
-*2. Add some cool label-translations/variants (@config/locale/en.yml@):*
+*2. Add some cool label-translations/variants (@config/locales/en.yml@):*
 
 <pre>
   en:


### PR DESCRIPTION
Should be `config/locales/en.yml`

Just a simple fix, confined to the README.
