### PR TITLE
Add ability to set custom class to the <li> wrapper.

### DIFF
--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -159,12 +159,13 @@ module Formtastic
       # {#inputs} will always create a new `<fieldset>` wrapping, so only use it when it makes sense
       # in the document structure and semantics (using `semantic_fields_for` otherwise).
       #
-      # All options except `:name`, `:title` and `:for` will be passed down to the fieldset as HTML
-      # attributes (id, class, style, etc).
+      # All options except `:name`, `:title`, `:wrapper_class` and `:for` will be passed down to the fieldset
+      # as HTML attributes (id, class, style, etc).
       #
       # When nesting `inputs()` inside another `inputs()` block, the nested content will 
       # automatically be wrapped in an `<li>` tag to preserve the HTML validity (a `<fieldset>`
-      # cannot be a direct descendant of an `<ol>`.
+      # cannot be a direct descendant of an `<ol>`. You can set a custom class for the `<li>`
+      # wrapper via `:wrapper_class` option.
       #
       #
       # @option *args :for [Symbol, ActiveModel, Array]
@@ -175,6 +176,9 @@ module Formtastic
       #
       # @option *args :title [String]
       #   The optional name passed into the `<legend>` tag within the fieldset (alias of `:name`)
+
+      # @option *args :wrapper_class [String]
+      #   The optional class for the `<li>` tag that wraps the `<fieldset>` if it is already nested in another `<fieldset>`.
       #
       #
       # @example Quick form: Render a scaffold-like set of inputs for automatically guessed attributes and simple associations on the model, with all default arguments and options
@@ -271,6 +275,9 @@ module Formtastic
         html_options[:class] ||= "inputs"
         html_options[:name] = title
 
+        wrapper_class = html_options.delete(:wrapper_class) || ''
+        wrapper_class += " input"
+
         out = begin
           if html_options[:for] # Nested form
             inputs_for_nested_attributes(*(args << html_options), &block)
@@ -285,7 +292,7 @@ module Formtastic
           end
         end
         
-        out = template.content_tag(:li, out, :class => "input") if wrap_it
+        out = template.content_tag(:li, out, :class => wrapper_class) if wrap_it
         @already_in_an_inputs_block = wrap_it
         out
       end

--- a/spec/helpers/inputs_helper_spec.rb
+++ b/spec/helpers/inputs_helper_spec.rb
@@ -542,6 +542,18 @@ describe 'Formtastic::FormBuilder#inputs' do
         output_buffer.should have_tag('form > fieldset.inputs > ol > li > fieldset.inputs > ol')
       end
     end
+
+    context "when nested (with block and :wrapper_class)" do
+      it "should wrap the nested inputs in an li block with a custom class" do
+        concat(semantic_form_for(@new_post) do |builder|
+          concat(builder.inputs do
+            concat(builder.inputs(:wrapper_class => 'custom_class') do |author_builder|
+            end)
+          end)
+        end)
+        output_buffer.should have_tag('form > fieldset.inputs > ol > li.custom_class.input > fieldset.inputs > ol')
+      end
+    end
     
     context "when nested (with block and :for)" do
       it "should wrap the nested inputs in an li block to maintain HTML validity" do


### PR DESCRIPTION
When nesting `inputs()` inside another `inputs()` block it is automatically wrapped in a `<li>` tag. Now you can add custom classes to this wrapper vi :wrapper_class option.
