### PR TITLE
Add docs badge to README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,6 +1,7 @@
 h1. Formtastic
 
 !https://travis-ci.org/justinfrench/formtastic.png?branch=master!:https://travis-ci.org/justinfrench/formtastic
+!http://inch-pages.github.io/github/justinfrench/formtastic.png!:http://inch-pages.github.io/github/justinfrench/formtastic
 !https://codeclimate.com/github/justinfrench/formtastic.png!:https://codeclimate.com/github/justinfrench/formtastic
 !https://badge.fury.io/rb/formtastic.png!:http://badge.fury.io/rb/formtastic
 !https://gemnasium.com/justinfrench/formtastic.png!:https://gemnasium.com/justinfrench/formtastic


### PR DESCRIPTION
Hi Justin,

this is the re-applied patch you asked for here: https://github.com/justinfrench/formtastic/pull/1000

I agree with the concerns you raised there. Especially regarding class- vs method-docs, but I have not come across a viable solution to this problem.

[Inch Pages](http://inch-pages.github.io) is supposed to be a project that tries to encourage aspiring Rubyists to document their code by showing that community veterans do it as well. The point should not be to achieve "100% docs" (which is why I don't use numbers in the badges).

I would be very happy if Formtastic would join this little movement!
