### PR TITLE
Whitelist only `for` and `class` attributes on BooleanInput label.

### DIFF
--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -51,21 +51,11 @@ module Formtastic
         )
       end
       
-      # TODO: why are we merging `input_html_options` and then making some of the irrelevant ones `nil`?
-      # Seems like we should be selectively including from input_html_options (a whitelist) instead of 
-      # excluding (blacklist).
       def label_html_options
-        prev = super
-        prev[:class] = prev[:class] - ['label']
-        
-        input_html_options.merge(
-          prev.merge(
-            :id   => nil,
-            :name => nil,
-            :tabindex => nil,
-            :for  => input_html_options[:id]
-          )
-        )
+        {
+          :for => input_html_options[:id],
+          :class => super[:class] - ['label'] # remove 'label' class
+        }
       end
 
       def label_text_with_embedded_checkbox

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -153,9 +153,10 @@ describe 'boolean input' do
   
   it 'should not pass input_html options down to the label html' do
     concat(semantic_form_for(@new_post) do |builder|
-      builder.input(:title, :as => :boolean, :input_html => { :tabindex => 2 })
+      builder.input(:title, :as => :boolean, :input_html => { :tabindex => 2, :x => "X" })
     end)
     output_buffer.should_not have_tag('label[tabindex]')
+    output_buffer.should_not have_tag('label[x]')
   end
 
   context "when required" do


### PR DESCRIPTION
Bug is reported in #995 and exposed through the changes in the spec. I can't figure out _why_ we used to merge our label options into `input_html_options`, but as the TODO previously stated, this is flawed. We should whitelist what we need only, to avoid attributes like `required` falling through.

Closes #995
