### PR TITLE
Deprecate anything under Rails 3.2.13

### DIFF
--- a/lib/formtastic/util.rb
+++ b/lib/formtastic/util.rb
@@ -38,7 +38,7 @@ module Formtastic
     end
     
     def deprecated_version_of_rails?
-      const_defined?(:Rails) && ::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MINOR < 2
+      const_defined?(:Rails) && ::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MINOR < 2 && ::Rails::VERSION::PATCH < 13
     end
 
   end


### PR DESCRIPTION
This is the release where hidden fields on multi selects were introduced, so this feels like a good minimum version for our next release. Related to #945.
