### PR TITLE
Simply Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: ruby
 before_install:
   - gem update --system
   - gem update bundler


### PR DESCRIPTION
I _think_ we can configure Travis with a simpler matrix (only showing allowed failures), and a complete list of Gemfiles. We were also missing a `language` key (defaults to ruby) when I ran `.travis.yml` through a validator.
