### PR TITLE
Exclude Ruby 2.1 from allowed build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,5 @@ matrix:
       gemfile: gemfiles/rails_edge.gemfile
       env: DEFER_GC=false RAILS_EDGE=true
     - rvm: 2.1.0
-      gemfile: gemfiles/rails_4.gemfile
-      env: DEFER_GC=false RAILS_EDGE=true
-    - rvm: 2.1.0
       gemfile: gemfiles/rails_edge.gemfile
       env: DEFER_GC=false RAILS_EDGE=true


### PR DESCRIPTION
Ruby 2.1.0 has been green on master for a few consecutive builds, let's commit to keeping it green.
