### PR TITLE
Revert "Support empty Time inputs"

### DIFF
--- a/lib/formtastic/inputs/time_select_input.rb
+++ b/lib/formtastic/inputs/time_select_input.rb
@@ -15,8 +15,12 @@ module Formtastic
         time_fragments
       end
       
+      def value_or_default_value
+        value ? value : Time.current
+      end
+      
       def fragment_value(fragment)
-        value ? value.send(fragment) : ""
+        value_or_default_value.send(fragment)
       end
       
       def hidden_fragments

--- a/spec/inputs/time_select_input_spec.rb
+++ b/spec/inputs/time_select_input_spec.rb
@@ -64,33 +64,6 @@ describe 'time select input' do
 
     end
 
-    describe "with :ignore_date => false and no initial Time" do
-      before do
-        @new_post.stub(:publish_at)
-        concat(semantic_form_for(@new_post) do |builder|
-          concat(builder.input(:publish_at, :as => :time_select, :ignore_date => false))
-        end)
-      end
-
-      it 'should have a hidden input for day, month and year' do
-        output_buffer.should have_tag('input#post_publish_at_1i')
-        output_buffer.should have_tag('input#post_publish_at_2i')
-        output_buffer.should have_tag('input#post_publish_at_3i')
-      end
-
-      it 'should not have values in hidden inputs for day, month and year' do
-        output_buffer.should have_tag('input#post_publish_at_1i[@value=""]')
-        output_buffer.should have_tag('input#post_publish_at_2i[@value=""]')
-        output_buffer.should have_tag('input#post_publish_at_3i[@value=""]')
-      end
-
-      it 'should have an select for hour and minute' do
-        output_buffer.should have_tag('select#post_publish_at_4i')
-        output_buffer.should have_tag('select#post_publish_at_5i')
-      end
-
-    end
-
     describe "without seconds" do
       before do
         concat(semantic_form_for(@new_post) do |builder|


### PR DESCRIPTION
See #901 for further information as to why this was reverted. Will merge in on green build. Fixes #901.
