### PR TITLE
Don’t render an ID if wrapper_html[:id] is nil

### DIFF
--- a/lib/formtastic/inputs/base/wrapping.rb
+++ b/lib/formtastic/inputs/base/wrapping.rb
@@ -3,33 +3,33 @@ module Formtastic
     module Base
       # @todo relies on `dom_id`, `required?`, `optional`, `errors?`, `association_primary_key` & `sanitized_method_name` methods from another module
       module Wrapping
-        
+
         # Override this method if you want to change the display order (for example, rendering the
         # errors before the body of the input).
         def input_wrapping(&block)
-          template.content_tag(:li, 
-            [template.capture(&block), error_html, hint_html].join("\n").html_safe, 
+          template.content_tag(:li,
+            [template.capture(&block), error_html, hint_html].join("\n").html_safe,
             wrapper_html_options
           )
         end
-        
+
         def wrapper_html_options
           opts = wrapper_html_options_raw
           opts[:class] = wrapper_classes
-          opts[:id] ||= wrapper_dom_id 
+          opts[:id] = wrapper_dom_id unless opts.has_key? :id
           opts
         end
-        
+
         def wrapper_html_options_raw
           (options[:wrapper_html] || {}).dup
         end
-        
+
         def wrapper_classes_raw
           classes = wrapper_html_options_raw[:class] || []
           return classes.dup if classes.is_a?(Array)
           return [classes]
         end
-        
+
         def wrapper_classes
           classes = wrapper_classes_raw
           classes << as
@@ -41,11 +41,11 @@ module Formtastic
 
           classes.join(' ')
         end
-        
+
         def wrapper_dom_id
           @wrapper_dom_id ||= "#{dom_id.to_s.gsub((association_primary_key || method).to_s, sanitized_method_name.to_s)}_input"
         end
-                
+
       end
     end
   end

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -821,6 +821,15 @@ describe 'Formtastic::FormBuilder#input' do
           output_buffer.should have_tag("form li.my_class")
           output_buffer.should have_tag("form li.another_class")
         end
+
+        describe 'when nil' do
+          it 'should not put an id attribute on the div tag' do
+            concat(semantic_form_for(@new_post) do |builder|
+              concat(builder.input(:title, :wrapper_html => {:id => nil}))
+            end)
+            output_buffer.should have_tag('form li:not([id])')
+          end
+        end
       end
 
       describe 'when not provided' do


### PR DESCRIPTION
At the moment, if `wrapper_html[:id]` is `nil`, the default wrapper ID gets rendered. It's sometimes desirable to take the `id` attribute off entirely—for example, in a page where client-side JavaScript may make an indeterminate number of copies of a form—but there hasn't been a good way to do that.

This pull request changes the behavior of `wrapper_html` so that if `:id` is `nil`, no `id` attribute gets rendered on the wrapper.
