### PR TITLE
remove rails < 3.1 stylesheet doc from readme

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -107,21 +107,6 @@ h2. Stylesheets
 
 A proof-of-concept set of stylesheets are provided which you can include in your layout. Customization is best achieved by overriding these styles in an additional stylesheet.
 
-h3. Stylesheet usage in Rails < 3.1:
-
-<pre>
-  $ rails generate formtastic:install
-</pre>
-
-<pre>
-  # app/views/layouts/application.html.erb
-  <%= stylesheet_link_tag 'formtastic', 'my_formtastic_changes' %>
-  <!--[if IE 6]><%= stylesheet_link_tag 'formtastic_ie6' %><![endif]-->
-  <!--[if IE 7]><%= stylesheet_link_tag 'formtastic_ie7' %><![endif]-->
-</pre>
-
-h3. Stylesheet usage in Rails >= 3.1:
-
 Rails 3.1 introduces an asset pipeline that allows plugins like Formtastic to serve their own Stylesheets, Javascripts, etc without having to run generators that copy them across to the host application. Formtastic makes three stylesheets available as an Engine, you just need to require them in your global stylesheets.
 
 <pre>


### PR DESCRIPTION
rails < 3.2 is deprecated, old assed installation is no longer needed
