### PR TITLE
Address rspec deprecation warnings fixes #1076

### DIFF
--- a/spec/builder/custom_builder_spec.rb
+++ b/spec/builder/custom_builder_spec.rb
@@ -39,8 +39,8 @@ describe 'Formtastic::Helpers::FormHelper.builder' do
     with_config(:all_fields_required_by_default, true) do
       MyCustomFormBuilder.all_fields_required_by_default = false
 
-      MyCustomFormBuilder.all_fields_required_by_default.should be_false
-      Formtastic::FormBuilder.all_fields_required_by_default.should be_true
+      MyCustomFormBuilder.all_fields_required_by_default.should be_falsey
+      Formtastic::FormBuilder.all_fields_required_by_default.should be_truthy
     end
   end
 

--- a/spec/builder/semantic_fields_for_spec.rb
+++ b/spec/builder/semantic_fields_for_spec.rb
@@ -29,16 +29,16 @@ describe 'Formtastic::FormBuilder#fields_for' do
     
     it 'should respond to input' do
       semantic_fields_for(@new_post) do |nested_builder|
-        nested_builder.respond_to?(:input).should be_true
+        nested_builder.respond_to?(:input).should be_truthy
       end
       semantic_fields_for(@new_post.author) do |nested_builder|
-        nested_builder.respond_to?(:input).should be_true
+        nested_builder.respond_to?(:input).should be_truthy
       end
       semantic_fields_for(:author, @new_post.author) do |nested_builder|
-        nested_builder.respond_to?(:input).should be_true
+        nested_builder.respond_to?(:input).should be_truthy
       end
       semantic_fields_for(:author, @hash_backed_author) do |nested_builder|
-        nested_builder.respond_to?(:input).should be_true
+        nested_builder.respond_to?(:input).should be_truthy
       end
     end
   end

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -113,7 +113,7 @@ describe 'check_boxes input' do
       end
 
       it "should mark input as checked if it's the the existing choice" do
-        ::Post.all.include?(@fred.posts.first).should be_true
+        ::Post.all.include?(@fred.posts.first).should be_truthy
         output_buffer.should have_tag("form li fieldset ol li label input[@checked='checked']")
       end
     end
@@ -179,7 +179,7 @@ describe 'check_boxes input' do
       end
 
       it "should mark input as checked if it's the the existing choice" do
-        ::Post.all.include?(@fred.posts.first).should be_true
+        ::Post.all.include?(@fred.posts.first).should be_truthy
         output_buffer.should have_tag("form li fieldset ol li label input[@checked='checked']")
       end
 

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -222,7 +222,7 @@ describe 'select input' do
 
   describe "for a belongs_to association with :conditions" do
     before do
-      ::Post.stub(:reflect_on_association).with(:author).and_return do
+      ::Post.stub(:reflect_on_association).with(:author) do
         mock = double('reflection', :options => {:conditions => {:active => true}}, :klass => ::Author, :macro => :belongs_to)
         mock.stub(:[]).with(:class_name).and_return("Author")
         mock

--- a/spec/localizer_spec.rb
+++ b/spec/localizer_spec.rb
@@ -16,8 +16,8 @@ describe 'Formtastic::Localizer' do
     end
     
     it "should check if key exists?" do
-      @cache.has_key?(@key).should be_true
-      @cache.has_key?(@undefined_key).should be_false
+      @cache.has_key?(@key).should be_truthy
+      @cache.has_key?(@undefined_key).should be_falsey
     end
     
     it "should set a key" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,7 +151,7 @@ module FormtasticSpecHelper
 
   ##
   # We can't mock :respond_to?, so we need a concrete class override
-  class ::MongoidReflectionMock < RSpec::Mocks::Mock
+  class ::MongoidReflectionMock < RSpec::Mocks::Double
     def initialize(name=nil, stubs_and_options={})
       super name, stubs_and_options
     end
@@ -300,9 +300,9 @@ module FormtasticSpecHelper
     ::Author.stub(:find).and_return(author_array_or_scope)
     ::Author.stub(:all).and_return(author_array_or_scope)
     ::Author.stub(:where).and_return(author_array_or_scope)
-    ::Author.stub(:human_attribute_name).and_return { |column_name| column_name.humanize }
+    ::Author.stub(:human_attribute_name) { |column_name| column_name.humanize }
     ::Author.stub(:human_name).and_return('::Author')
-    ::Author.stub(:reflect_on_association).and_return { |column_name| double('reflection', :options => {}, :klass => Post, :macro => :has_many) if column_name == :posts }
+    ::Author.stub(:reflect_on_association) { |column_name| double('reflection', :options => {}, :klass => Post, :macro => :has_many) if column_name == :posts }
     ::Author.stub(:content_columns).and_return([double('column', :name => 'login'), double('column', :name => 'created_at')])
     ::Author.stub(:to_key).and_return(nil)
     ::Author.stub(:persisted?).and_return(nil)
@@ -347,12 +347,12 @@ module FormtasticSpecHelper
     @fred.stub(:post_ids).and_return([@freds_post.id])
 
     ::Post.stub(:scoped).and_return(::Post)
-    ::Post.stub(:human_attribute_name).and_return { |column_name| column_name.humanize }
+    ::Post.stub(:human_attribute_name) { |column_name| column_name.humanize }
     ::Post.stub(:human_name).and_return('Post')
     ::Post.stub(:reflect_on_all_validations).and_return([])
     ::Post.stub(:reflect_on_validations_for).and_return([])
     ::Post.stub(:reflections).and_return({})
-    ::Post.stub(:reflect_on_association).and_return do |column_name|
+    ::Post.stub(:reflect_on_association) { |column_name|
       case column_name
       when :author, :author_status
         mock = double('reflection', :options => {}, :klass => ::Author, :macro => :belongs_to)
@@ -373,7 +373,7 @@ module FormtasticSpecHelper
              :options => Proc.new { raise NoMethodError, "Mongoid has no reflection.options" },
              :klass => ::Author, :macro => :referenced_in, :foreign_key => "reviewer_id") # custom id
       end
-    end
+    }
     ::Post.stub(:find).and_return(author_array_or_scope([@freds_post]))
     ::Post.stub(:all).and_return(author_array_or_scope([@freds_post]))
     ::Post.stub(:where).and_return(author_array_or_scope([@freds_post]))
@@ -382,7 +382,7 @@ module FormtasticSpecHelper
     ::Post.stub(:persisted?).and_return(nil)
     ::Post.stub(:to_ary)
 
-    ::MongoPost.stub(:human_attribute_name).and_return { |column_name| column_name.humanize }
+    ::MongoPost.stub(:human_attribute_name) { |column_name| column_name.humanize }
     ::MongoPost.stub(:human_name).and_return('MongoPost')
     ::MongoPost.stub(:associations).and_return({
       :sub_posts => double('reflection', :options => {:polymorphic => true}, :klass => ::MongoPost, :macro => :has_many),
@@ -525,6 +525,8 @@ end
 ::ActiveSupport::Deprecation.silenced = false
 
 RSpec.configure do |config|
+  config.infer_spec_type_from_file_location!
+
   config.before(:each) do
     Formtastic::Localizer.cache.clear!    
   end

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -459,7 +459,7 @@ module CustomMacros
 
             describe "when the collection objects respond to #{label_method}" do
               before do
-                @fred.stub(:respond_to?).and_return { |m| m.to_s == label_method || m.to_s == 'id' }
+                @fred.stub(:respond_to?) { |m| m.to_s == label_method || m.to_s == 'id' }
                 [@fred, @bob].each { |a| a.stub(label_method).and_return('The Label Text') }
 
                 concat(semantic_form_for(@new_post) do |builder|

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -10,56 +10,56 @@ describe 'Formtastic::Util' do
     context '4.0.0' do
       before { allow(Formtastic::Util).to receive(:rails_version) { Gem::Version.new("4.0.0") } }
       it 'should be true' do
-        expect(subject).to be_true
+        expect(subject).to be_truthy
       end
     end
 
     context '4.0.3' do
       before { allow(Formtastic::Util).to receive(:rails_version) { Gem::Version.new("4.0.3") } }
       it 'should be true' do
-        expect(subject).to be_true
+        expect(subject).to be_truthy
       end
     end
 
     context '4.0.4' do
       before { allow(Formtastic::Util).to receive(:rails_version) { Gem::Version.new("4.0.4") } }
       it 'should be false' do
-        expect(subject).to be_true
+        expect(subject).to be_truthy
       end
     end
 
     context '4.0.5' do
       before { allow(Formtastic::Util).to receive(:rails_version) { Gem::Version.new("4.0.5") } }
       it 'should be false' do
-        expect(subject).to be_true
+        expect(subject).to be_truthy
       end
     end
 
     context '4.1.0' do
       before { allow(Formtastic::Util).to receive(:rails_version) { Gem::Version.new("4.1.1") } }
       it 'should be false' do
-        expect(subject).to be_false
+        expect(subject).to be_falsey
       end
     end
 
     context '4.1.1' do
       before { allow(Formtastic::Util).to receive(:rails_version) { Gem::Version.new("4.1.1") } }
       it 'should be false' do
-        expect(subject).to be_false
+        expect(subject).to be_falsey
       end
     end
 
     context '4.2.0' do
       before { allow(Formtastic::Util).to receive(:rails_version) { Gem::Version.new("4.1.1") } }
       it 'should be false' do
-        expect(subject).to be_false
+        expect(subject).to be_falsey
       end
     end
 
     context '5.0.0' do
       before { allow(Formtastic::Util).to receive(:rails_version) { Gem::Version.new("5.0.0") } }
       it 'should be true' do
-        expect(subject).to be_false
+        expect(subject).to be_falsey
       end
     end
   end


### PR DESCRIPTION
- `Mock` => `Double`
- `and_return { value }` => `and_return(value)`
- `be_false` => `be_falsey`
- `be_true` => `be_truthy`
- `config.infer_spec_type_from_file_location!` (we don't rely on this, but adding it silenced the last deprecation)
