### PR TITLE
Update input_helper.rb

### DIFF
--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -233,7 +233,7 @@ module Formtastic
       # @todo Many many more examples. Some of the detail probably needs to be pushed out to the relevant methods too.
       # @todo More i18n examples.
       def input(method, options = {})
-        method = method.to_sym if method.is_a?(String)
+        method = method.to_sym
         options = options.dup # Allow options to be shared without being tainted by Formtastic
         options[:as] ||= default_input_type(method, options)
 


### PR DESCRIPTION
It's faster to don't check the type!

``` ruby
Benchmark.bm(30) do |x|
  [:foo, "bar"].each do |method|
    x.report("with check and type #{method.class}:")    { 100_000.times { method.to_sym if method.is_a?(String) } }
    x.report("without check and type #{method.class}:") { 100_000.times { method.to_sym } }
  end
end
```

```
                                     user     system      total        real
with check and type Symbol:      0.010000   0.000000   0.010000 (  0.011005)
without check and type Symbol:   0.010000   0.000000   0.010000 (  0.007977)
with check and type String:      0.020000   0.000000   0.020000 (  0.017717)
without check and type String:   0.010000   0.000000   0.010000 (  0.012937)
```

`Symbol#to_sym` is just a `return self`, `Object#is_a?` is quite more!
