### PR TITLE
use AR 4.x pluck for collection labeling

### DIFF
--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -144,6 +144,9 @@ module Formtastic
       # @option options :member_value [Symbol, Proc, Method]
       #   Override the method called on each object in the `:collection` for use as the `value` attribute in the `<input>` (`:check_boxes` & `:radio` inputs) or `<option>` (`:select` inputs)
       #
+      # @option options :member_sql [String, Arel.sql, Array<String, Arel.sql>]
+      #   Passes the option value to `collection#pluck` to get the label and value, without loading the whole record. This option is only supported on Rails 4.x and don't work with :member_label or :member_value
+      #
       # @option options :multiple [Boolean]
       #   Specify if the `:select` input should allow multiple selections or not (defaults to `belongs_to` associations, and `true` for `has_many` and `has_and_belongs_to_many` associations)
       #

--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -42,6 +42,10 @@ module Formtastic
           [label, value]
         end
 
+        def member_sql
+          options[:member_sql]
+        end
+
         def raw_collection
           @raw_collection ||= (collection_from_options || collection_from_association || collection_for_boolean)
         end
@@ -54,6 +58,9 @@ module Formtastic
           return raw_collection if (raw_collection.instance_of?(Array) || raw_collection.instance_of?(Range)) &&
                                [Array, Fixnum, String].include?(raw_collection.first.class) &&
                                !(options.include?(:member_label) || options.include?(:member_value))
+
+          # Return if we have a collection that supports `pluck` (ActiveRecord > 4.0) and a the member_sql option is set
+          return raw_collection.pluck(member_sql) if raw_collection.respond_to?(:pluck) && member_sql
 
           raw_collection.map { |o| [send_or_call(label_method, o), send_or_call(value_method, o)] }
         end

--- a/lib/formtastic/inputs/base/options.rb
+++ b/lib/formtastic/inputs/base/options.rb
@@ -8,7 +8,7 @@ module Formtastic
         end
         
         def formtastic_options
-          [:priority_countries, :priority_zones, :member_label, :member_value, :collection, :required, :label, :as, :hint, :input_html, :value_as_class, :class]
+          [:priority_countries, :priority_zones, :member_label, :member_value, :member_sql, :collection, :required, :label, :as, :hint, :input_html, :value_as_class, :class]
         end
       
       end

--- a/spec/inputs/label_spec.rb
+++ b/spec/inputs/label_spec.rb
@@ -84,6 +84,18 @@ describe 'Formtastic::FormBuilder#label' do
     end
   end
 
+  describe 'when member_sql is given' do
+    it 'should use the member_sql value to pluck the value from the database' do
+      member_sql = "CONCAT(`name`, '-', `lastname`), `id`"
+      Author.all.should_receive(:pluck).with(member_sql).and_return([[[@fred.name, @fred.lastname].join("-"), @fred.id], [[@bob.name, @bob.lastname].join("-"), @bob.id]])
+      concat(semantic_form_for(:project, :url => 'http://test.host') do |builder|
+        concat(builder.input(:author_id, :as => :select, :collection => Author.all, :member_sql => member_sql))
+      end)
+      output_buffer.should have_tag('form li select option[value="37"]', "Fred-Smith")
+      output_buffer.should have_tag('form li select option[value="42"]', "Bob-Rock")
+    end
+  end
+
   describe 'when label is given' do
     it 'should allow the text to be given as label option' do
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -267,6 +267,7 @@ module FormtasticSpecHelper
     @fred.stub(:to_key).and_return(nil)
     @fred.stub(:persisted?).and_return(nil)
     @fred.stub(:name).and_return('Fred')
+    @fred.stub(:lastname).and_return('Smith')
 
     @bob = ::Author.new
     @bob.stub(:to_label).and_return('Bob Rock')
@@ -281,6 +282,7 @@ module FormtasticSpecHelper
     @bob.stub(:to_key).and_return(nil)
     @bob.stub(:persisted?).and_return(nil)
     @bob.stub(:name).and_return('Bob')
+    @bob.stub(:lastname).and_return('Rock')
 
     @james = ::Author.new
     @james.stub(:to_label).and_return('James Shock')
@@ -294,6 +296,7 @@ module FormtasticSpecHelper
     @james.stub(:to_key).and_return(nil)
     @james.stub(:persisted?).and_return(nil)
     @james.stub(:name).and_return('James')
+    @james.stub(:lastname).and_return('Shock')
 
 
     ::Author.stub(:scoped).and_return(::Author)


### PR DESCRIPTION
If you have a collection with hundreds of items, formtastic loads all of them to get the `member_label` and `member_value` of it. That is very slow! Since Rails 4 has a [`pluck`](http://apidock.com/rails/ActiveRecord/Calculations/pluck) method, we can go a more performant way!
With `pluck` only the requested fields are loaded form the DB.

This PR is inspired by @seanlinsley in activeadmin/activeadmin#2166
