### PR TITLE
Add german translations

### DIFF
--- a/lib/locale/de.yml
+++ b/lib/locale/de.yml
@@ -1,0 +1,10 @@
+en:
+  formtastic:
+    :yes: 'Ja'
+    :no: 'Nein'
+    :create: '%{model} erstellen'
+    :update: '%{model} aktualisieren'
+    :submit: '%{model} abschicken'
+    :cancel: '%{model} abbrechen'
+    :reset: '%{model} zurücksetzen'
+    :required: 'erforderlich'


### PR DESCRIPTION
Just some default german translations. Currently active_admin with german locale displays english buttons where formtastic is used.

The 'cancel' translation generally sounds weird to me, do you really "Cancel Post" when you want to cancel editing a post? I'd say it should be just "Cancel" and "Abbrechen" in german.
