### PR TITLE
Use `eager_load` instead of `cache_classes` in `NamespacedClassFinder`

### DIFF
--- a/lib/formtastic/namespaced_class_finder.rb
+++ b/lib/formtastic/namespaced_class_finder.rb
@@ -28,6 +28,10 @@ module Formtastic
     class NotFoundError < NameError
     end
 
+    def self.use_const_defined?
+      defined?(Rails) && ::Rails.application && ::Rails.application.config.eager_load
+    end
+
     # @param namespaces [Array<Module>]
     def initialize(namespaces)
       @namespaces = namespaces.flatten
@@ -62,7 +66,7 @@ module Formtastic
 
     private
 
-    if defined?(Rails) && ::Rails.application && ::Rails.application.config.cache_classes
+    if use_const_defined?
       def finder(class_name) # @private
         find_with_const_defined(class_name)
       end


### PR DESCRIPTION
I get an error in my tests with the custom inputs in my forms on a Rails 4.1.8 app with Formtastic 3.1.0 when using the new finders.
In my test environment, where I have `eager_load = false` and `cache_classes = true`, the classes are not found (`ActionView::Template::Error: Unable to find input class ...Input`).

In `formtastic/helpers/input_helper.rb`, `eager_load` is used to determine if `const_defined?` should be used.
But in the new finders, `cache_classes` is used.
Is there a reason for this change ?
