### PR TITLE
Fix incorrect Rails version in deprecation notice

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -23,7 +23,7 @@ module Formtastic
   self.deprecation = Formtastic::Deprecation.new('4.0', 'Formtastic')
 
   if defined?(::Rails) && Util.deprecated_version_of_rails?
-    deprecation.warn("Support for Rails < 4.0.4 will be dropped ")
+    deprecation.warn("Support for Rails < #{Util.minimum_version_of_rails} will be dropped")
   end
 
   # @public

--- a/lib/formtastic/util.rb
+++ b/lib/formtastic/util.rb
@@ -38,7 +38,11 @@ module Formtastic
     end
 
     def deprecated_version_of_rails?
-      match?(rails_version, "< 4.1.0")
+      match?(rails_version, "< #{minimum_version_of_rails}")
+    end
+
+    def minimum_version_of_rails
+      "4.1.0"
     end
 
     def rails_version


### PR DESCRIPTION
extracts minimum rails version out to a method and use that in the deprecation warning message
