### PR TITLE
Wrap checkbox and radiobutton labels with span

### DIFF
--- a/lib/formtastic/inputs/base/choices.rb
+++ b/lib/formtastic/inputs/base/choices.rb
@@ -44,11 +44,13 @@ module Formtastic
         end
 
         def choice_label(choice)
-          if choice.is_a?(Array)
+          '<span>'.html_safe +
+          (if choice.is_a?(Array)
             choice.first
           else
             choice
-          end.to_s
+          end.to_s) +
+          '</span>'.html_safe
         end
 
         def choice_value(choice)

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -161,8 +161,16 @@ describe 'check_boxes input' do
         end)
 
         output_buffer.should have_tag('form li fieldset ol li label') do |label|
-          label.body.should match /&lt;b&gt;Item [12]&lt;\/b&gt;$/
+          label.body.should match /&lt;b&gt;Item [12]&lt;\/b&gt;/
         end
+      end
+
+      it 'should wrap label in a span' do
+        concat(semantic_form_for(:project, :url => 'http://test.host') do |builder|
+          concat(builder.input(:author_id, :as => :check_boxes, :collection => [["<b>Item 1</b>", 1], ["<b>Item 2</b>", 2]]))
+        end)
+
+        output_buffer.should have_tag('form li fieldset ol li label input+span')
       end
     end
 

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -137,8 +137,15 @@ describe 'radio input' do
           concat(builder.input(:author_id, :as => :radio, :collection => [["<b>Item 1</b>", 1], ["<b>Item 2</b>", 2]]))
         end)
         output_buffer.should have_tag('form li fieldset ol li label') do |label|
-          label.body.should match /&lt;b&gt;Item [12]&lt;\/b&gt;$/
+          label.body.should match /&lt;b&gt;Item [12]&lt;\/b&gt;/
         end
+      end
+
+      it 'should wrap label string in a span' do
+        concat(semantic_form_for(:project, :url => 'http://test.host') do |builder|
+          concat(builder.input(:author_id, :as => :radio, :collection => [["<b>Item 1</b>", 1], ["<b>Item 2</b>", 2]]))
+        end)
+        output_buffer.should have_tag('form li fieldset ol li label input+span')
       end
 
       it 'should generate inputs for each item' do


### PR DESCRIPTION
Currently styling checkboxes and radiobuttons is only possible via hiding checkbox input and styling element  (usually `label` or `span`) next to it, as it allows to handle checkbox/radiobutton state via `:checked` pseudoclass (see http://stackoverflow.com/questions/4148499/how-to-style-checkbox-using-css).
Given formtastic places inputs inside label tags, I have implemented wrapping choice labels with `span`s.
