### PR TITLE
In Rails 3, Rails.application.config does not respond to eager_load.

### DIFF
--- a/lib/formtastic/namespaced_class_finder.rb
+++ b/lib/formtastic/namespaced_class_finder.rb
@@ -29,7 +29,7 @@ module Formtastic
     end
 
     def self.use_const_defined?
-      defined?(Rails) && ::Rails.application && ::Rails.application.config.eager_load
+      defined?(Rails) && ::Rails.application && ::Rails.application.config.respond_to?(:eager_load) && ::Rails.application.config.eager_load
     end
 
     # @param namespaces [Array<Module>]


### PR DESCRIPTION
Hi, here's a PR fixing #1135.

With this patch in place, my 3.2.21 test application will boot.

However, I don't know enough about the inner workings of formtastic across different versions of Rails to assess whether or not this will break something else or not.

Can someone who knows have a look at this?