### PR TITLE
Discover fields on a form object not just ActiveRecord

### DIFF
--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -310,6 +310,7 @@ module Formtastic
       def default_columns_for_object
         cols  = association_columns(:belongs_to)
         cols += content_columns
+        cols += form_object_fields
         cols -= Formtastic::FormBuilder.skipped_columns
         cols.compact
       end
@@ -331,6 +332,14 @@ module Formtastic
         end
       end
       
+      # Collects fields from a form object that responds to this method
+      # If you'd like to implement on your form object just need to return a array of symbols
+      # [:field1, :field2]
+      def form_object_fields
+        return [] unless @object.respond_to?(:form_object_fields)
+        @object.form_object_fields
+      end
+
       # Collects association columns (relation columns) for the current form object class. Skips
       # polymorphic associations because we can't guess which class to use for an automatically
       # generated input.


### PR DESCRIPTION
WIP: Need to check the [Reform PR](https://github.com/apotonick/reform/pull/212), then I add tests and doc before merge, just opened this PR so we can discuss seeing some code.

This PR is related to https://github.com/justinfrench/formtastic/issues/1141

My proposal to solve the problem on the issue, without affecting the behavior with AR models, so this way I just add a method on Reform to expose the fields key, then formtastic can consume on its InputsHelper

//cc @apotonick