### PR TITLE
Add auto readonly

### DIFF
--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -135,6 +135,7 @@ module Formtastic
       #
       # @option options :input_html [Hash]
       #   Override or add to the HTML attributes to be passed down to the `<input>` tag
+      #   (If you use attr_readonly method in your model, formtastic will automatically set those attributes's input readonly)
       #
       # @option options :wrapper_html [Hash]
       #   Override or add to the HTML attributes to be passed down to the wrapping `<li>` tag

--- a/lib/formtastic/inputs/base/html.rb
+++ b/lib/formtastic/inputs/base/html.rb
@@ -2,7 +2,7 @@ module Formtastic
   module Inputs
     module Base
       module Html
-        
+
         # Defines how the instance of an input should be rendered to a HTML string.
         #
         # @abstract Implement this method in your input class to describe how the input should render itself.
@@ -17,15 +17,16 @@ module Formtastic
         def to_html
           raise NotImplementedError
         end
-        
+
         def input_html_options
-          { 
+          {
             :id => dom_id,
             :required => required_attribute?,
-            :autofocus => autofocus?
+            :autofocus => autofocus?,
+            :readonly => readonly?
           }.merge(options[:input_html] || {})
         end
-        
+
         def dom_id
           [
             builder.dom_id_namespace,
@@ -34,7 +35,7 @@ module Formtastic
             association_primary_key || sanitized_method_name
           ].reject { |x| x.blank? }.join('_')
         end
-        
+
         def dom_index
           if builder.options.has_key?(:index)
             builder.options[:index]

--- a/lib/formtastic/inputs/base/options.rb
+++ b/lib/formtastic/inputs/base/options.rb
@@ -2,15 +2,14 @@ module Formtastic
   module Inputs
     module Base
       module Options
-        
+
         def input_options
           options.except(*formtastic_options)
         end
-        
+
         def formtastic_options
           [:priority_countries, :priority_zones, :member_label, :member_value, :collection, :required, :label, :as, :hint, :input_html, :value_as_class, :class]
         end
-      
       end
     end
   end

--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -193,8 +193,7 @@ module Formtastic
         end
 
         def readonly?
-          opt_readonly = options[:input_html] && options[:input_html][:readonly]
-          opt_readonly || readonly_attribute?
+          readonly_from_options? || readonly_attribute?
         end
 
         def readonly_attribute?
@@ -202,6 +201,10 @@ module Formtastic
           object_class.respond_to?(:readonly_attributes) &&
             self.object.persisted? &&
             object_class.readonly_attributes.include?(column.name.to_s)
+        end
+
+        def readonly_from_options?
+          options[:input_html] && options[:input_html][:readonly]
         end
       end
     end

--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -192,6 +192,16 @@ module Formtastic
           validation_limit || column_limit
         end
 
+        def readonly?
+          opt_readonly = options[:input_html] && options[:input_html][:readonly]
+          opt_readonly || readonly_attribute?
+        end
+
+        def readonly_attribute?
+          column.class.respond_to?(:readonly_attributes) &&
+            column.persisted? &&
+            column.class.readonly_attributes.include?(column_name.to_s)
+        end
       end
     end
   end

--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -199,7 +199,6 @@ module Formtastic
 
         def readonly_attribute?
           object_class = self.object.class
-          puts object_class
           object_class.respond_to?(:readonly_attributes) &&
             self.object.persisted? &&
             object_class.readonly_attributes.include?(column.name.to_s)

--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -199,6 +199,7 @@ module Formtastic
 
         def readonly_attribute?
           object_class = self.object.class
+          puts object_class
           object_class.respond_to?(:readonly_attributes) &&
             self.object.persisted? &&
             object_class.readonly_attributes.include?(column.name.to_s)

--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -198,9 +198,10 @@ module Formtastic
         end
 
         def readonly_attribute?
-          column.class.respond_to?(:readonly_attributes) &&
-            column.persisted? &&
-            column.class.readonly_attributes.include?(column_name.to_s)
+          object_class = self.object.class
+          object_class.respond_to?(:readonly_attributes) &&
+            self.object.persisted? &&
+            object_class.readonly_attributes.include?(column.name.to_s)
         end
       end
     end

--- a/spec/inputs/country_input_spec.rb
+++ b/spec/inputs/country_input_spec.rb
@@ -56,7 +56,7 @@ describe 'country input' do
       priority_countries = ["Foo", "Bah"]
       semantic_form_for(@new_post) do |builder|
         builder.stub(:country_select).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
-        builder.should_receive(:country_select).with(:country, priority_countries, {}, {:id => "post_country", :required => false, :autofocus => false}).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
+        builder.should_receive(:country_select).with(:country, priority_countries, {}, {:id => "post_country", :required => false, :autofocus => false, :readonly => false}).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
 
         concat(builder.input(:country, :as => :country, :priority_countries => priority_countries))
       end
@@ -69,7 +69,7 @@ describe 'country input' do
 
       semantic_form_for(@new_post) do |builder|
         builder.stub(:country_select).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
-        builder.should_receive(:country_select).with(:country, priority_countries, {}, {:id => "post_country", :required => false, :autofocus => false}).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
+        builder.should_receive(:country_select).with(:country, priority_countries, {}, {:id => "post_country", :required => false, :autofocus => false, :readonly => false}).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
 
         concat(builder.input(:country, :as => :country))
       end
@@ -85,7 +85,7 @@ describe 'country input' do
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         builder.stub(:country_select).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
-        builder.should_receive(:country_select).with(:country, [], {}, {:id => "context2_post_country", :required => false, :autofocus => false}).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
+        builder.should_receive(:country_select).with(:country, [], {}, {:id => "context2_post_country", :required => false, :autofocus => false, :readonly => false}).and_return(Formtastic::Util.html_safe("<select><option>...</option></select>"))
         concat(builder.input(:country, :priority_countries => []))
       end)
     end

--- a/spec/inputs/readonly_spec.rb
+++ b/spec/inputs/readonly_spec.rb
@@ -16,7 +16,7 @@ describe 'readonly option' do
 
       describe "for #{type} inputs" do
 
-        describe "when options set readonly" do
+        describe "when readonly is found in input_html" do
           it "sets readonly attribute" do
             concat(semantic_form_for(@new_post) do |builder|
               concat(builder.input(:title, :as => type, input_html: {readonly: true}))
@@ -36,6 +36,8 @@ describe 'readonly option' do
           end
           describe "when column is readonly attribute" do
             it "sets readonly attribute" do
+              input_class = "Formtastic::Inputs::#{type.to_s.camelize}Input".constantize
+              expect_any_instance_of(input_class).to receive(:readonly_attribute?).at_least(1).and_return(true)
               concat(semantic_form_for(@new_post) do |builder|
                 concat(builder.input(:title, :as => type))
               end)

--- a/spec/inputs/readonly_spec.rb
+++ b/spec/inputs/readonly_spec.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe 'readonly option' do
+
+  include FormtasticSpecHelper
+
+  before do
+    @output_buffer = ''
+    mock_everything
+  end
+
+  describe "placeholder text" do
+
+    [:email, :number, :password, :phone, :search, :string, :url, :text, :date_picker, :time_picker, :datetime_picker].each do |type|
+
+      describe "for #{type} inputs" do
+
+        describe "when options set readonly" do
+          it "sets readonly attribute" do
+            concat(semantic_form_for(@new_post) do |builder|
+              concat(builder.input(:title, :as => type, input_html: {readonly: true}))
+            end)
+              output_buffer.should have_tag((type == :text ? 'textarea' : 'input') + '[@readonly]')
+          end
+        end
+
+        describe "when readonly not found in input_html" do
+          describe "when column is not readonly attribute" do
+            it "doesn't set readonly attribute" do
+              concat(semantic_form_for(@new_post) do |builder|
+                concat(builder.input(:title, :as => type))
+              end)
+                output_buffer.should_not have_tag((type == :text ? 'textarea' : 'input') + '[@readonly]')
+            end
+          end
+          describe "when column is readonly attribute" do
+            it "sets readonly attribute" do
+              concat(semantic_form_for(@new_post) do |builder|
+                concat(builder.input(:title, :as => type))
+              end)
+                output_buffer.should have_tag((type == :text ? 'textarea' : 'input') + '[@readonly]')
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
ActiveRecord has a method called [attr_readonly](http://apidock.com/rails/ActiveRecord/Base/attr_readonly/class), which can set attributes unupdatable. So I think it would be nice if formtastic can detect those readonly attributes and set their input readonly.(SimpleForm already did that)