### PR TITLE
Fix #1161

### DIFF
--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -200,6 +200,7 @@ module Formtastic
           object_class = self.object.class
           object_class.respond_to?(:readonly_attributes) &&
             self.object.persisted? &&
+            column.respond_to?(:name) &&
             object_class.readonly_attributes.include?(column.name.to_s)
         end
 

--- a/spec/inputs/readonly_spec.rb
+++ b/spec/inputs/readonly_spec.rb
@@ -11,7 +11,6 @@ describe 'readonly option' do
   end
 
   describe "placeholder text" do
-
     [:email, :number, :password, :phone, :search, :string, :url, :text, :date_picker, :time_picker, :datetime_picker].each do |type|
 
       describe "for #{type} inputs" do


### PR DESCRIPTION
Now will check if `column` is present and respond_to `name` method in readonly option's validation.
I haven't figure out how to reproduce the context mentioned in #1161 , but I think this should fix it.