### PR TITLE
Add test-unit development dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
 gemfile:
   - gemfiles/rails_3.2.gemfile
   - gemfiles/rails_4.gemfile
@@ -14,6 +15,8 @@ gemfile:
   - gemfiles/rails_edge.gemfile
 env:
   - DEFER_GC=false RAILS_EDGE=true
+before_install:
+  - gem install bundler -v 1.10.6
 script: "bundle exec rake spec"
 matrix:
   allow_failures:
@@ -24,5 +27,8 @@ matrix:
       gemfile: gemfiles/rails_edge.gemfile
       env: DEFER_GC=false RAILS_EDGE=true
     - rvm: 2.1
+      gemfile: gemfiles/rails_edge.gemfile
+      env: DEFER_GC=false RAILS_EDGE=true
+    - rvm: 2.2
       gemfile: gemfiles/rails_edge.gemfile
       env: DEFER_GC=false RAILS_EDGE=true

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -28,14 +28,14 @@ Gem::Specification.new do |s|
   s.add_dependency(%q<actionpack>, [">= 3.2.13"])
 
   s.add_development_dependency(%q<nokogiri>)
-  s.add_development_dependency(%q<rspec-rails>, ["~> 2.14"])
+  s.add_development_dependency(%q<rspec-rails>, ["~> 3.3.2"])
   s.add_development_dependency(%q<rspec_tag_matchers>, ["~> 1.0"])
   s.add_development_dependency(%q<hpricot>, ["~> 0.8.3"])
   s.add_development_dependency(%q<RedCloth>, ["~> 4.2"]) # for YARD Textile formatting
   s.add_development_dependency(%q<yard>, ["~> 0.8"])
   s.add_development_dependency(%q<colored>, ["~> 1.2"])
   s.add_development_dependency(%q<tzinfo>)
-  s.add_development_dependency(%q<ammeter>, ["1.1.1"])
+  s.add_development_dependency(%q<ammeter>, ["~> 1.1.3"])
   s.add_development_dependency(%q<appraisal>, ["~> 1.0"])
   s.add_development_dependency(%q<rake>)
   s.add_development_dependency(%q<activemodel>, [">= 3.2.13"])

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -4,4 +4,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 3.2.0"
 
+gem "test-unit-minitest", :platform => :ruby_22
+
 gemspec :path => "../"

--- a/lib/formtastic/inputs/country_input.rb
+++ b/lib/formtastic/inputs/country_input.rb
@@ -67,8 +67,10 @@ module Formtastic
     class CountryInput 
       include Base
 
+      CountrySelectPluginMissing = Class.new(StandardError)
+
       def to_html
-        raise "To use the :country input, please install a country_select plugin, like this one: https://github.com/stefanpenner/country_select" unless builder.respond_to?(:country_select)
+        raise CountrySelectPluginMissing, "To use the :country input, please install a country_select plugin, like this one: https://github.com/stefanpenner/country_select" unless builder.respond_to?(:country_select)
         input_wrapping do
           label_html <<
           builder.country_select(method, priority_countries, input_options, input_html_options)

--- a/spec/inputs/country_input_spec.rb
+++ b/spec/inputs/country_input_spec.rb
@@ -17,7 +17,7 @@ describe 'country input' do
         semantic_form_for(@new_post) do |builder|
           concat(builder.input(:country, :as => :country))
         end
-      }.should raise_error
+      }.should raise_error(Formtastic::Inputs::CountryInput::CountrySelectPluginMissing)
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -492,29 +492,8 @@ module FormtasticSpecHelper
     Formtastic::FormBuilder.send(:"#{config_method_name}=", old_value)
   end
   
-  class ToSMatcher
-    def initialize(str)
-      @str=str.to_s
-    end
-    
-    def matches?(value)
-      value.to_s==@str
-    end
-    
-    def failure_message_for_should
-      "Expected argument that converted to #{@str}"
-    end
-  end
-  
-  def errors_matcher(method)
-    # In edge rails (Rails 4) tags store method_name as a string and index the errors object using a string
-    # therefore allow stubs to match on either string or symbol.  The errors object calls to_sym on all index 
-    # accesses so @object.errors[:abc] is equivalent to @object.errors["abc"]
-    if Rails::VERSION::MAJOR == 4
-      ToSMatcher.new(method)
-    else
-      method
-    end
+  RSpec::Matchers.define :errors_matcher do |expected|
+    match { |actual| actual.to_s == expected.to_s }
   end
 end
 


### PR DESCRIPTION
I was setting up development environment and got a crash when running on Ruby 2.2.3:

```
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-rails-2.99.0/lib/rspec/rails/adapters.rb:17:in `require': cannot load such file -- test/unit/assertions (LoadError)
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-rails-2.99.0/lib/rspec/rails/adapters.rb:17:in `rescue in <module:Rails>'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-rails-2.99.0/lib/rspec/rails/adapters.rb:12:in `<module:Rails>'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-rails-2.99.0/lib/rspec/rails/adapters.rb:6:in `<module:RSpec>'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-rails-2.99.0/lib/rspec/rails/adapters.rb:5:in `<top (required)>'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/ammeter-1.1.1/lib/ammeter/rspec/generator/example/generator_example_group.rb:3:in `require'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/ammeter-1.1.1/lib/ammeter/rspec/generator/example/generator_example_group.rb:3:in `<top (required)>'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/ammeter-1.1.1/lib/ammeter/rspec/generator/example.rb:2:in `require'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/ammeter-1.1.1/lib/ammeter/rspec/generator/example.rb:2:in `<top (required)>'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/ammeter-1.1.1/lib/ammeter/init.rb:7:in `require'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/ammeter-1.1.1/lib/ammeter/init.rb:7:in `<top (required)>'
	from /path/to/Development/formtastic/spec/spec_helper.rb:20:in `require'
	from /path/to/Development/formtastic/spec/spec_helper.rb:20:in `<top (required)>'
	from /path/to/Development/formtastic/spec/action_class_finder_spec.rb:2:in `require'
	from /path/to/Development/formtastic/spec/action_class_finder_spec.rb:2:in `<top (required)>'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1065:in `load'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1065:in `block in load_spec_files'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1065:in `each'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1065:in `load_spec_files'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:18:in `run'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
	from /path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'
```

Starting from Ruby 2.2.0 ``Test::Unit`` was removed from standard library. You got to add it to your Gemfile.