### PR TITLE
Hint at "appraisal install" in contributing guide

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -601,6 +601,7 @@ There are none other than Rails itself, but...
 h2. How to contribute
 
 * Fork the project on Github
+* Install development dependencies (@bundle install@ and @appraisal install@)
 * Create a topic branch for your changes
 * Ensure that you provide *documentation* and *test coverage* for your changes (patches won't be accepted without)
 * Ensure that all tests pass (`bundle exec rake`)


### PR DESCRIPTION
It wasn't obvious to me how to set up development environment for formtastic. I looked at contributing guide and it didn't help. I think a hint at ``appraisal install`` there would help.