### PR TITLE
Support validation contexts as Array

### DIFF
--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -138,7 +138,8 @@ module Formtastic
           if validations?
             validations.select { |validator|
               if validator.options.key?(:on)
-                return false if (validator.options[:on] != :save) && ((object.new_record? && validator.options[:on] != :create) || (!object.new_record? && validator.options[:on] != :update))
+                validator_on = Array(validator.options[:on])
+                return false if (validator_on.exclude?(:save)) && ((object.new_record? && validator_on.exclude?(:create)) || (!object.new_record? && validator_on.exclude?(:update)))
               end
               case validator.kind
               when :presence

--- a/spec/inputs/base/validations_spec.rb
+++ b/spec/inputs/base/validations_spec.rb
@@ -1,0 +1,294 @@
+require 'fast_spec_helper'
+require 'inputs/base/validations'
+
+class MyInput
+  include Formtastic::Inputs::Base::Validations
+end
+
+describe MyInput do
+  let(:builder) { double }
+  let(:template) { double }
+  let(:model_class) { double }
+  let(:model) { double(:class => model_class) }
+  let(:model_name) { "post" }
+  let(:method) { double }
+  let(:options) { Hash.new }
+  let(:validator) { double }
+  let(:instance) { MyInput.new(builder, template, model, model_name, method, options) }
+
+  describe '#required?' do
+    before :each do
+      allow(instance).to receive(:validations?).and_return(:true)
+      allow(instance).to receive(:validations).and_return([validator])
+    end
+
+    context 'with options[:required] being true' do
+      let(:options) { {required: true} }
+
+      it 'is required' do
+        expect(instance.required?).to be_truthy
+      end
+    end
+
+    context 'with options[:required] being false' do
+      let(:options) { {required: false} }
+
+      it 'is not required' do
+        expect(instance.required?).to be_falsey
+      end
+    end
+
+    context 'with negated validation' do
+      it 'is not required' do
+        instance.not_required_through_negated_validation!
+        expect(instance.required?).to be_falsey
+      end
+    end
+
+    context 'with presence validator' do
+      let (:validator) { double(options: {}, kind: :presence) }
+
+      it 'is required' do
+        expect(instance.required?).to be_truthy
+      end
+
+      context 'with options[:on] as symbol' do
+        context 'with save context' do
+          let (:validator) { double(options: {on: :save}, kind: :presence) }
+
+          it 'is required' do
+            expect(instance.required?).to be_truthy
+          end
+        end
+
+        context 'with create context' do
+          let (:validator) { double(options: {on: :create}, kind: :presence) }
+
+          it 'is required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_truthy
+          end
+
+          it 'is not required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_falsey
+          end
+        end
+
+        context 'with update context' do
+          let (:validator) { double(options: {on: :update}, kind: :presence) }
+
+          it 'is not required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_falsey
+          end
+
+          it 'is required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_truthy
+          end
+        end
+      end
+
+      context 'with options[:on] as array' do
+        context 'with save context' do
+          let (:validator) { double(options: {on: [:save]}, kind: :presence) }
+
+          it 'is required' do
+            expect(instance.required?).to be_truthy
+          end
+        end
+
+        context 'with create context' do
+          let (:validator) { double(options: {on: [:create]}, kind: :presence) }
+
+          it 'is required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_truthy
+          end
+
+          it 'is not required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_falsey
+          end
+        end
+
+        context 'with update context' do
+          let (:validator) { double(options: {on: [:update]}, kind: :presence) }
+
+          it 'is not required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_falsey
+          end
+
+          it 'is required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_truthy
+          end
+        end
+
+        context 'with save and create context' do
+          let (:validator) { double(options: {on: [:save, :create]}, kind: :presence) }
+
+          it 'is required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_truthy
+          end
+
+          it 'is required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_truthy
+          end
+        end
+
+        context 'with save and update context' do
+          let (:validator) { double(options: {on: [:save, :create]}, kind: :presence) }
+
+          it 'is required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_truthy
+          end
+
+          it 'is required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_truthy
+          end
+        end
+
+        context 'with create and update context' do
+          let (:validator) { double(options: {on: [:create, :update]}, kind: :presence) }
+
+          it 'is required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_truthy
+          end
+
+          it 'is required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_truthy
+          end
+        end
+
+        context 'with save and other context' do
+          let (:validator) { double(options: {on: [:save, :foo]}, kind: :presence) }
+
+          it 'is required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_truthy
+          end
+
+          it 'is required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_truthy
+          end
+        end
+
+        context 'with create and other context' do
+          let (:validator) { double(options: {on: [:create, :foo]}, kind: :presence) }
+
+          it 'is required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_truthy
+          end
+
+          it 'is not required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_falsey
+          end
+        end
+
+        context 'with update and other context' do
+          let (:validator) { double(options: {on: [:update, :foo]}, kind: :presence) }
+
+          it 'is not required for new records' do
+            allow(model).to receive(:new_record?).and_return(true)
+            expect(instance.required?).to be_falsey
+          end
+
+          it 'is required for existing records' do
+            allow(model).to receive(:new_record?).and_return(false)
+            expect(instance.required?).to be_truthy
+          end
+        end
+      end
+    end
+
+    context 'with inclusion validator' do
+      context 'with allow blank' do
+        let (:validator) { double(options: {allow_blank: true}, kind: :inclusion) }
+
+        it 'is not required' do
+          expect(instance.required?).to be_falsey
+        end
+      end
+
+      context 'without allow blank' do
+        let (:validator) { double(options: {allow_blank: false}, kind: :inclusion) }
+
+        it 'is required' do
+          expect(instance.required?).to be_truthy
+        end
+      end
+    end
+
+    context 'with a length validator' do
+      context 'with allow blank' do
+        let (:validator) { double(options: {allow_blank: true}, kind: :length) }
+
+        it 'is not required' do
+          expect(instance.required?).to be_falsey
+        end
+      end
+
+      context 'without allow blank' do
+        let (:validator) { double(options: {allow_blank: false}, kind: :length) }
+
+        it 'is not required' do
+          expect(instance.required?).to be_falsey
+        end
+
+        context 'with a minimum > 0' do
+          let (:validator) { double(options: {allow_blank: false, minimum: 1}, kind: :length) }
+
+          it 'is required' do
+            expect(instance.required?).to be_truthy
+          end
+        end
+
+        context 'with a minimum <= 0' do
+          let (:validator) { double(options: {allow_blank: false, minimum: 0}, kind: :length) }
+
+          it 'is not required' do
+            expect(instance.required?).to be_falsey
+          end
+        end
+
+        context 'with a defined range starting with > 0' do
+          let (:validator) { double(options: {allow_blank: false, within: 1..5}, kind: :length) }
+
+          it 'is required' do
+            expect(instance.required?).to be_truthy
+          end
+        end
+
+        context 'with a defined range starting with <= 0' do
+          let (:validator) { double(options: {allow_blank: false, within: 0..5}, kind: :length) }
+
+          it 'is not required' do
+            expect(instance.required?).to be_falsey
+          end
+        end
+      end
+    end
+
+    context 'with another validator' do
+      let (:validator) { double(options: {allow_blank: true}, kind: :foo) }
+
+      it 'is not required' do
+        expect(instance.required?).to be_falsey
+      end
+    end
+  end
+
+end
+

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -490,10 +490,36 @@ RSpec.shared_examples 'Input Helper' do
               end
             end
 
+            it 'should be required when there is :create option in validation contexts array on create' do
+              with_config :required_string, " required yo!" do
+                @new_post.class.should_receive(:validators_on).with(:title).at_least(:once).and_return([
+                                                                                                         active_model_presence_validator([:title], {:on => [:create]})
+                                                                                                       ])
+                concat(semantic_form_for(@new_post) do |builder|
+                  concat(builder.input(:title))
+                end)
+                output_buffer.should have_tag('form li.required')
+                output_buffer.should_not have_tag('form li.optional')
+              end
+            end
+
             it 'should be required when there is :on => :save option on create' do
               with_config :required_string, " required yo!" do
                 @new_post.class.should_receive(:validators_on).with(:title).at_least(:once).and_return([
                                                                                                            active_model_presence_validator([:title], {:on => :save})
+                                                                                                       ])
+                concat(semantic_form_for(@new_post) do |builder|
+                  concat(builder.input(:title))
+                end)
+                output_buffer.should have_tag('form li.required')
+                output_buffer.should_not have_tag('form li.optional')
+              end
+            end
+
+            it 'should be required when there is :save option in validation contexts array on create' do
+              with_config :required_string, " required yo!" do
+                @new_post.class.should_receive(:validators_on).with(:title).at_least(:once).and_return([
+                                                                                                         active_model_presence_validator([:title], {:on => [:save]})
                                                                                                        ])
                 concat(semantic_form_for(@new_post) do |builder|
                   concat(builder.input(:title))
@@ -516,6 +542,19 @@ RSpec.shared_examples 'Input Helper' do
               end
             end
 
+            it 'should be required when there is :save option in validation contexts array on update' do
+              with_config :required_string, " required yo!" do
+                @fred.class.should_receive(:validators_on).with(:login).at_least(:once).and_return([
+                                                                                                     active_model_presence_validator([:login], {:on => [:save]})
+                                                                                                   ])
+                concat(semantic_form_for(@fred) do |builder|
+                  concat(builder.input(:login))
+                end)
+                output_buffer.should have_tag('form li.required')
+                output_buffer.should_not have_tag('form li.optional')
+              end
+            end
+
             it 'should not be required when there is :on => :create option on update' do
               @fred.class.should_receive(:validators_on).with(:login).at_least(:once).and_return([
                                                                                                      active_model_presence_validator([:login], {:on => :create})
@@ -527,9 +566,31 @@ RSpec.shared_examples 'Input Helper' do
               output_buffer.should have_tag('form li.optional')
             end
 
+            it 'should not be required when there is :create option in validation contexts array on update' do
+              @fred.class.should_receive(:validators_on).with(:login).at_least(:once).and_return([
+                                                                                                   active_model_presence_validator([:login], {:on => [:create]})
+                                                                                                 ])
+              concat(semantic_form_for(@fred) do |builder|
+                concat(builder.input(:login))
+              end)
+              output_buffer.should_not have_tag('form li.required')
+              output_buffer.should have_tag('form li.optional')
+            end
+
             it 'should not be required when there is :on => :update option on create' do
               @new_post.class.should_receive(:validators_on).with(:title).at_least(:once).and_return([
                                                                                                          active_model_presence_validator([:title], {:on => :update})
+                                                                                                     ])
+              concat(semantic_form_for(@new_post) do |builder|
+                concat(builder.input(:title))
+              end)
+              output_buffer.should_not have_tag('form li.required')
+              output_buffer.should have_tag('form li.optional')
+            end
+
+            it 'should not be required when there is :update option in validation contexts array on create' do
+              @new_post.class.should_receive(:validators_on).with(:title).at_least(:once).and_return([
+                                                                                                       active_model_presence_validator([:title], {:on => [:update]})
                                                                                                      ])
               concat(semantic_form_for(@new_post) do |builder|
                 concat(builder.input(:title))


### PR DESCRIPTION
Hello Justin,

i added support for displaying a field as required, when the validation context in the model is specified as an array to have multiple validation contexts for a validation.
I would be very happy if this could be merged.

Thanks in advance
Moritz