### PR TITLE
Treat input as :string if attached `column.type` is empty

### DIFF
--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -261,7 +261,8 @@ module Formtastic
           return :file    if is_file?(method, options)
         end
 
-        if column = column_for(method)
+        column = column_for(method)
+        if column && column.type
           # Special cases where the column type doesn't map to an input method.
           case column.type
           when :string


### PR DESCRIPTION
`#column_for` can return `ActiveRecord::ConnectionAdapters::NullColumn`. `column.type` will be `nil` then.
This fix makes the InputHelper#default_input_type recognize such column as string by default, just as the whole `column` would be `nil`.

Fixes the `Unable to find input class Input` error (justinfrench/formtastic#1183).