### PR TITLE
the changelog improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG merge=union

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+master
+
+  * Fixed missing constants in production (#911)
+  * Removed support for Rails 3 and 4.0 (#1108)
+  * Removed deprecated input/action finder methods (#1139)
+
+
 3.1.2
 
   * Fixed that we specified 4.0.4 instead of 4.1 in the Rails version deprecation message


### PR DESCRIPTION
it was quite hard to write a changelog for almost a year of changes
so I propose that we try to keep it in sync with what is merged

to do that, this pr adds missing entries and configures merge strategy
so conflicts are resolved by using both entries