### PR TITLE
[travis] explicitely cache root bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
-cache: bundler
+cache:
+  - bundler
+  - directories:
+    - vendor/bundle
 language: ruby
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ gemfile:
 before_install:
   - gem install bundler --version 1.11.2
   - export BUNDLE_PATH="${TRAVIS_BUILD_DIR}/vendor/bundle"
+before_cache:
+  - rm -f ${BUNDLE_PATH}/**/extensions/**/{gem_make.out,mkmf.log}
 script:
  - bundle exec rake spec
  - script/integration.sh


### PR DESCRIPTION
to be sure travis caches all bundle installed gems for faster builds

it is not 100% successful, because the gems from integration test are removed via bundle clean, see https://github.com/travis-ci/travis-ci/issues/2518 for details

It improves the build time by about a minute.