### PR TITLE
Replace RSpec Tag Matchers

### DIFF
--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency(%q<nokogiri>)
   s.add_development_dependency(%q<rspec-rails>, ["~> 3.4.2"])
-  s.add_development_dependency(%q<rspec_tag_matchers>, ["~> 1.0"])
+  s.add_development_dependency(%q<rspec-dom-testing>, [">= 0.1.0"])
   s.add_development_dependency(%q<hpricot>, ["~> 0.8.3"])
   s.add_development_dependency(%q<RedCloth>, ["~> 4.2"]) # for YARD Textile formatting
   s.add_development_dependency(%q<yard>, ["~> 0.8"])

--- a/spec/helpers/actions_helper_spec.rb
+++ b/spec/helpers/actions_helper_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Formtastic::FormBuilder#actions' do
       end
 
       it 'should render the contents of the block inside the ol' do
-        expect(output_buffer).to have_tag("form fieldset.actions ol", /hello/)
+        expect(output_buffer).to have_tag("form fieldset.actions ol", :text => /hello/)
       end
 
       it 'should not render a legend inside the fieldset' do
@@ -47,7 +47,7 @@ RSpec.describe 'Formtastic::FormBuilder#actions' do
         end)
       end
       it 'should render a fieldset inside the form' do
-        expect(output_buffer).to have_tag("form fieldset.actions legend", /#{@legend_text}/)
+        expect(output_buffer).to have_tag("form fieldset.actions legend", :text => /#{@legend_text}/)
       end
     end
     
@@ -132,7 +132,7 @@ RSpec.describe 'Formtastic::FormBuilder#actions' do
      end
     
      it 'should use the special :name option as a text for the legend tag' do
-       expect(output_buffer).to have_tag('form > fieldset#my-id.actions > legend', /Now click a button/)
+       expect(output_buffer).to have_tag('form > fieldset#my-id.actions > legend', :text => /Now click a button/)
      end
     
     end

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'with input class finder' do
             concat(semantic_form_for(@new_post) do |builder|
               concat(builder.input(:title, :required => true))
             end)
-            expect(output_buffer).to have_tag('form li.required label', /required yo/)
+            expect(output_buffer).to have_tag('form li.required label', :text => /required yo/)
           end
         end
       end
@@ -78,7 +78,7 @@ RSpec.describe 'with input class finder' do
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:title, :required => false))
           end)
-          expect(output_buffer).to have_tag('form li.optional label', /#{@string}$/)
+          expect(output_buffer).to have_tag('form li.optional label', :text => /#{@string}$/)
         end
 
       end
@@ -594,7 +594,7 @@ RSpec.describe 'with input class finder' do
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:title, :label => "Kustom"))
           end)
-          expect(output_buffer).to have_tag("form li label", /Kustom/)
+          expect(output_buffer).to have_tag("form li label", :text => /Kustom/)
         end
 
         it 'should not generate a label if false' do
@@ -608,7 +608,7 @@ RSpec.describe 'with input class finder' do
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:title, :label => "Kustom".freeze))
           end)
-          expect(output_buffer).to have_tag("form li label", /Kustom/)
+          expect(output_buffer).to have_tag("form li label", :text => /Kustom/)
         end
       end
 
@@ -630,7 +630,7 @@ RSpec.describe 'with input class finder' do
                   concat(semantic_form_for(@new_post) do |builder|
                     concat(builder.input(:meta_description))
                   end)
-                  expect(output_buffer).to have_tag('form li label', /Localized title/)
+                  expect(output_buffer).to have_tag('form li label', :text => /Localized title/)
                 end
               end
             end
@@ -645,7 +645,7 @@ RSpec.describe 'with input class finder' do
                 concat(semantic_form_for(:project, :url => 'http://test.host') do |builder|
                   concat(builder.input(:meta_description))
                 end)
-                expect(output_buffer).to have_tag("form li label", /#{'meta_description'.humanize}/)
+                expect(output_buffer).to have_tag("form li label", :text => /#{'meta_description'.humanize}/)
               end
             end
           end
@@ -658,7 +658,7 @@ RSpec.describe 'with input class finder' do
               concat(semantic_form_for(@new_post) do |builder|
                 concat(builder.input(:meta_description))
               end)
-              expect(output_buffer).to have_tag("form li label", /#{'meta_description'.humanize}/)
+              expect(output_buffer).to have_tag("form li label", :text => /#{'meta_description'.humanize}/)
             end
           end
 
@@ -670,7 +670,7 @@ RSpec.describe 'with input class finder' do
                 concat(semantic_form_for(@new_post) do |builder|
                   concat(builder.input(:meta_description))
                 end)
-                expect(output_buffer).to have_tag("form li label", /#{'meta_description'.capitalize}/)
+                expect(output_buffer).to have_tag("form li label", :text => /#{'meta_description'.capitalize}/)
               end
             end
           end
@@ -699,7 +699,7 @@ RSpec.describe 'with input class finder' do
                 concat(builder.input(:title, :label => true))
                 concat(builder.input(:published, :as => :boolean, :label => true))
               end)
-              expect(output_buffer).to have_tag('form li label', Regexp.new('^' + @localized_label_text))
+              expect(output_buffer).to have_tag('form li label', :text => Regexp.new('^' + @localized_label_text))
             end
           end
 
@@ -718,7 +718,7 @@ RSpec.describe 'with input class finder' do
                 concat(builder.input(:title, :label => true))
                 concat(builder.input(:published, :as => :boolean, :label => true))
               end)
-              expect(output_buffer).to have_tag('form li label', Regexp.new('^' + @default_localized_label_text))
+              expect(output_buffer).to have_tag('form li label', :text => Regexp.new('^' + @default_localized_label_text))
             end
           end
         end
@@ -739,7 +739,7 @@ RSpec.describe 'with input class finder' do
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:title, :hint => hint_text))
           end)
-          expect(output_buffer).to have_tag("form li p.inline-hints", hint_text)
+          expect(output_buffer).to have_tag("form li p.inline-hints", :text => hint_text)
         end
 
         it 'should have a custom hint class defaulted for all forms' do
@@ -748,7 +748,7 @@ RSpec.describe 'with input class finder' do
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:title, :hint => hint_text))
           end)
-          expect(output_buffer).to have_tag("form li p.custom-hint-class", hint_text)
+          expect(output_buffer).to have_tag("form li p.custom-hint-class", :text => hint_text)
         end
       end
 
@@ -783,7 +783,7 @@ RSpec.describe 'with input class finder' do
                 concat(semantic_form_for(@new_post) do |builder|
                   concat(builder.input(:title, :hint => true))
                 end)
-                expect(output_buffer).to have_tag('form li p.inline-hints', @localized_hint_text)
+                expect(output_buffer).to have_tag('form li p.inline-hints', :text => @localized_hint_text)
               end
             end
 
@@ -792,7 +792,7 @@ RSpec.describe 'with input class finder' do
                 concat(semantic_form_for(@new_post) do |builder|
                   concat(builder.input(:title, :hint => true))
                 end)
-                expect(output_buffer).to have_tag('form li p.inline-hints', @default_localized_hint_text)
+                expect(output_buffer).to have_tag('form li p.inline-hints', :text => @default_localized_hint_text)
               end
             end
           end
@@ -803,7 +803,7 @@ RSpec.describe 'with input class finder' do
                 concat(semantic_form_for(@new_post) do |builder|
                   concat(builder.input(:title, :hint => false))
                 end)
-                expect(output_buffer).not_to have_tag('form li p.inline-hints', @localized_hint_text)
+                expect(output_buffer).not_to have_tag('form li p.inline-hints', :text => @localized_hint_text)
               end
             end
           end
@@ -823,7 +823,7 @@ RSpec.describe 'with input class finder' do
               semantic_form_for(@new_post) do |builder|
                 concat(builder.input(:title, :hint => true))
               end
-              expect(output_buffer).not_to have_tag('form li p.inline-hints', @localized_hint_text)
+              expect(output_buffer).not_to have_tag('form li p.inline-hints', :text => @localized_hint_text)
             end
           end
         end

--- a/spec/helpers/inputs_helper_spec.rb
+++ b/spec/helpers/inputs_helper_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
       end
   
       it 'should render the contents of the block inside the ol' do
-        expect(output_buffer).to have_tag("form fieldset.inputs ol", /hello/)
+        expect(output_buffer).to have_tag("form fieldset.inputs ol", :text => /hello/)
       end
   
       it 'should not render a legend inside the fieldset' do
@@ -49,7 +49,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
             concat('bye')
           end
         end)
-        expect(output_buffer).to have_tag("form fieldset.inputs ol", /bye/)
+        expect(output_buffer).to have_tag("form fieldset.inputs ol", :text => /bye/)
       end
     end
   
@@ -117,8 +117,8 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
           
           expect(output_buffer).to have_tag("form fieldset.inputs", :count => 2)
           expect(output_buffer).to have_tag("form fieldset.inputs legend", :count => 2)
-          expect(output_buffer).to have_tag("form fieldset.inputs legend", "1", :count => 1)
-          expect(output_buffer).to have_tag("form fieldset.inputs legend", "2")
+          expect(output_buffer).to have_tag("form fieldset.inputs legend", :text => "1", :count => 1)
+          expect(output_buffer).to have_tag("form fieldset.inputs legend", :text => "2")
           expect(output_buffer).to have_tag("form input[@name='post[authors_attributes][0][login]']")
           expect(output_buffer).to have_tag("form input[@name='post[authors_attributes][1][login]']")
           expect(output_buffer).not_to have_tag('form fieldset[@name]')
@@ -131,8 +131,8 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
             end
           end)
           
-          expect(output_buffer).to have_tag("form fieldset.inputs label", "1", :count => 1)
-          expect(output_buffer).to have_tag("form fieldset.inputs label", "2", :count => 1)
+          expect(output_buffer).to have_tag("form fieldset.inputs label", :text => "1", :count => 1)
+          expect(output_buffer).to have_tag("form fieldset.inputs label", :text => "2", :count => 1)
           expect(output_buffer).not_to have_tag('form fieldset legend')
         end
       end
@@ -209,7 +209,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
           concat(inputs)
         end)
   
-        expect(output_buffer).to have_tag('fieldset legend', 'Author #1')
+        expect(output_buffer).to have_tag('fieldset legend', :text => 'Author #1')
       end
   
       it 'should also provide child index interpolation for legends when nested child index is a hash' do
@@ -221,7 +221,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
           concat(inputs)
         end)
   
-        expect(output_buffer).to have_tag('fieldset legend', 'Author #11')
+        expect(output_buffer).to have_tag('fieldset legend', :text => 'Author #11')
       end
       
       it 'should send parent_builder as an option to allow child index interpolation for labels' do
@@ -233,7 +233,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
           concat(inputs)
         end)
         
-        expect(output_buffer).to have_tag('fieldset label', 'Author #1')
+        expect(output_buffer).to have_tag('fieldset label', :text => 'Author #1')
       end
       
       it 'should also provide child index interpolation for labels when nested child index is a hash' do
@@ -245,7 +245,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
           concat(inputs)
         end)
         
-        expect(output_buffer).to have_tag('fieldset label', 'Author #11')
+        expect(output_buffer).to have_tag('fieldset label', :text => 'Author #11')
       end
     end
   
@@ -274,10 +274,10 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
         
         # TODO: looks like the block isn't being called for the last assertion here
         it 'should render a fieldset with a legend inside the form' do
-          expect(output_buffer).to have_tag("form fieldset legend", /^#{@legend_text}$/)
-          expect(output_buffer).to have_tag("form fieldset legend", /^#{@legend_text_using_name}$/)
-          expect(output_buffer).to have_tag("form fieldset legend", /^#{@legend_text_using_title}$/)
-          expect(output_buffer).to have_tag("form fieldset legend", /^#{@nested_forms_legend_text}$/)
+          expect(output_buffer).to have_tag("form fieldset legend", :text => /^#{@legend_text}$/)
+          expect(output_buffer).to have_tag("form fieldset legend", :text => /^#{@legend_text_using_name}$/)
+          expect(output_buffer).to have_tag("form fieldset legend", :text => /^#{@legend_text_using_title}$/)
+          expect(output_buffer).to have_tag("form fieldset legend", :text => /^#{@nested_forms_legend_text}$/)
         end
       end
   
@@ -311,10 +311,10 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
         
         # TODO: looks like the block isn't being called for the last assertion here
         it 'should render a fieldset with a localized legend inside the form' do
-          expect(output_buffer).to have_tag("form fieldset legend", /^#{@localized_legend_text}$/)
-          expect(output_buffer).to have_tag("form fieldset legend", /^#{@localized_legend_text_using_name}$/)
-          expect(output_buffer).to have_tag("form fieldset legend", /^#{@localized_legend_text_using_title}$/)
-          expect(output_buffer).to have_tag("form fieldset legend", /^#{@localized_nested_forms_legend_text}$/)
+          expect(output_buffer).to have_tag("form fieldset legend", :text => /^#{@localized_legend_text}$/)
+          expect(output_buffer).to have_tag("form fieldset legend", :text => /^#{@localized_legend_text_using_name}$/)
+          expect(output_buffer).to have_tag("form fieldset legend", :text => /^#{@localized_legend_text_using_title}$/)
+          expect(output_buffer).to have_tag("form fieldset legend", :text => /^#{@localized_nested_forms_legend_text}$/)
         end
       end
     end
@@ -512,8 +512,8 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
       end
   
       it 'should use the special :name option as a text for the legend tag' do
-        expect(output_buffer).to have_tag('form > fieldset#my-id.inputs > legend', /^#{@legend_text_using_option}$/)
-        expect(output_buffer).to have_tag('form > fieldset#my-id-2.inputs > legend', /^#{@legend_text_using_arg}$/)
+        expect(output_buffer).to have_tag('form > fieldset#my-id.inputs > legend', :text => /^#{@legend_text_using_option}$/)
+        expect(output_buffer).to have_tag('form > fieldset#my-id-2.inputs > legend', :text => /^#{@legend_text_using_arg}$/)
       end
     end
 

--- a/spec/helpers/semantic_errors_helper_spec.rb
+++ b/spec/helpers/semantic_errors_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
 
     it 'should render an unordered list' do
       semantic_form_for(@new_post) do |builder|
-        expect(builder.semantic_errors).to have_tag('ul.errors li', @base_error)
+        expect(builder.semantic_errors).to have_tag('ul.errors li', :text => @base_error)
       end
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
       semantic_form_for(@new_post) do |builder|
         expect(builder.semantic_errors).to have_tag('ul.errors')
         @base_errors.each do |error|
-          expect(builder.semantic_errors).to have_tag('ul.errors li', error)
+          expect(builder.semantic_errors).to have_tag('ul.errors li', :text => error)
         end
       end
     end
@@ -51,7 +51,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     it 'should render an unordered list' do
       semantic_form_for(@new_post) do |builder|
         title_name = builder.send(:localized_string, :title, :title, :label) || builder.send(:humanized_attribute_name, :title)
-        expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', title_name << " " << @title_errors.to_sentence)
+        expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', :text => title_name << " " << @title_errors.to_sentence)
       end
     end
   end
@@ -65,8 +65,8 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     it 'should render an unordered list' do
       semantic_form_for(@new_post) do |builder|
         title_name = builder.send(:localized_string, :title, :title, :label) || builder.send(:humanized_attribute_name, :title)
-        expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', title_name << " " << @title_errors.to_sentence)
-        expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', @base_error)
+        expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', :text => title_name << " " << @title_errors.to_sentence)
+        expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', :text => @base_error)
       end
     end
   end
@@ -91,7 +91,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
 
     it 'should render an unordered list with given class' do
       semantic_form_for(@new_post) do |builder|
-        expect(builder.semantic_errors(:class => "awesome")).to have_tag('ul.awesome li', @base_error)
+        expect(builder.semantic_errors(:class => "awesome")).to have_tag('ul.awesome li', :text => @base_error)
       end
     end
   end
@@ -104,7 +104,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     it 'should ignore :base and only render base errors once' do
       semantic_form_for(@new_post) do |builder|
         expect(builder.semantic_errors(:base)).to have_tag('ul li', :count => 1)
-        expect(builder.semantic_errors(:base)).not_to have_tag('ul li', "Base #{@base_error}")
+        expect(builder.semantic_errors(:base)).not_to have_tag('ul li', :text => "Base #{@base_error}")
       end
     end
   end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Formtastic::I18n' do
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:title))
         end)
-        expect(output_buffer).to have_tag("form label", /Hello post!/)
+        expect(output_buffer).to have_tag("form label", :text => /Hello post!/)
       end
     end
 
@@ -126,7 +126,7 @@ RSpec.describe 'Formtastic::I18n' do
         concat(semantic_form_for(:project, :url => 'http://test.host') do |builder|
           concat(builder.input(:title))
         end)
-        expect(output_buffer).to have_tag("form label", /Hello project!/)
+        expect(output_buffer).to have_tag("form label", :text => /Hello project!/)
       end
     end
 
@@ -135,7 +135,7 @@ RSpec.describe 'Formtastic::I18n' do
         concat(semantic_form_for(:project, :url => 'http://test.host') do |builder|
           concat(builder.input(:author))
         end)
-        expect(output_buffer).to have_tag("form label", /Author/)
+        expect(output_buffer).to have_tag("form label", :text => /Author/)
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe 'Formtastic::I18n' do
             concat(f.input(:name))
           end)
         end)
-        expect(output_buffer).to have_tag("form label", /Hello author name!/)
+        expect(output_buffer).to have_tag("form label", :text => /Hello author name!/)
       end
     end
 
@@ -157,7 +157,7 @@ RSpec.describe 'Formtastic::I18n' do
             concat(f.input(:name))
           end
         end)
-        expect(output_buffer).to have_tag("form label", /Hello author name!/)
+        expect(output_buffer).to have_tag("form label", :text => /Hello author name!/)
       end
     end
 
@@ -168,7 +168,7 @@ RSpec.describe 'Formtastic::I18n' do
             concat(f.input(:title))
           end
         end)
-        expect(output_buffer).to have_tag("form label", /Hello project!/)
+        expect(output_buffer).to have_tag("form label", :text => /Hello project!/)
       end
     end
     
@@ -179,7 +179,7 @@ RSpec.describe 'Formtastic::I18n' do
             concat(f.input(:name))
           end
         end)
-        expect(output_buffer).to have_tag("form label", /Hello author name!/)
+        expect(output_buffer).to have_tag("form label", :text => /Hello author name!/)
       end
     end
 
@@ -188,7 +188,7 @@ RSpec.describe 'Formtastic::I18n' do
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:body))
         end)
-        expect(output_buffer).to have_tag("form label", /Elaborate/)
+        expect(output_buffer).to have_tag("form label", :text => /Elaborate/)
       end
     end
     
@@ -199,7 +199,7 @@ RSpec.describe 'Formtastic::I18n' do
             concat(f.input(:login))
           end)
         end)
-        expect(output_buffer).to have_tag("form label", /Hello login/)
+        expect(output_buffer).to have_tag("form label", :text => /Hello login/)
       end
     end
 

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'boolean input' do
     expect(output_buffer).not_to have_tag('label.label')
     expect(output_buffer).to have_tag('form li label', :count => 1)
     expect(output_buffer).to have_tag('form li label[@for="post_allow_comments"]')
-    expect(output_buffer).to have_tag('form li label', /Allow comments/)
+    expect(output_buffer).to have_tag('form li label', :text => /Allow comments/)
     expect(output_buffer).to have_tag('form li label input[@type="checkbox"]', :count => 1)
     expect(output_buffer).to have_tag('form li input[@type="hidden"]', :count => 1)
     expect(output_buffer).not_to have_tag('form li label input[@type="hidden"]', :count => 1) # invalid HTML5
@@ -167,7 +167,7 @@ RSpec.describe 'boolean input' do
     end)
 
     expect(output_buffer).to have_tag('form li label[@for="project_allow_comments"]')
-    expect(output_buffer).to have_tag('form li label', /Allow comments/)
+    expect(output_buffer).to have_tag('form li label', :text => /Allow comments/)
     expect(output_buffer).to have_tag('form li label input[@type="checkbox"]')
 
     expect(output_buffer).to have_tag('form li label input#project_allow_comments')

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'check_boxes input' do
 
     it 'should generate a legend containing a label with text for the input' do
       expect(output_buffer).to have_tag('form li fieldset legend.label label')
-      expect(output_buffer).to have_tag('form li fieldset legend.label label', /Posts/)
+      expect(output_buffer).to have_tag('form li fieldset legend.label label', :text => /Posts/)
     end
 
     it 'should not link the label within the legend to any input' do
@@ -72,7 +72,7 @@ RSpec.describe 'check_boxes input' do
 
       it 'should contain a label for the radio input with a nested input and label text' do
         ::Post.all.each do |post|
-          expect(output_buffer).to have_tag('form li fieldset ol li label', /#{post.to_label}/)
+          expect(output_buffer).to have_tag('form li fieldset ol li label', :text => /#{post.to_label}/)
           expect(output_buffer).to have_tag("form li fieldset ol li label[@for='author_post_ids_#{post.id}']")
         end
       end
@@ -112,7 +112,7 @@ RSpec.describe 'check_boxes input' do
         ::Post.all.each do |post|
           expect(output_buffer).to have_tag("form li fieldset ol li label input#author_post_ids_#{post.id}")
           expect(output_buffer).to have_tag("form li fieldset ol li label input[@name='author[post_ids][]']", :count => 2)
-          expect(output_buffer).to have_tag('form li fieldset ol li label', /#{post.to_label}/)
+          expect(output_buffer).to have_tag('form li fieldset ol li label', :text => /#{post.to_label}/)
         end
 
       end
@@ -132,7 +132,7 @@ RSpec.describe 'check_boxes input' do
       end
 
       it 'should generate a fieldset with legend' do
-        expect(output_buffer).to have_tag('form li fieldset legend', /Author/)
+        expect(output_buffer).to have_tag('form li fieldset legend', :text => /Author/)
       end
 
       it 'shold generate an li tag for each item in the collection' do
@@ -141,7 +141,7 @@ RSpec.describe 'check_boxes input' do
 
       it 'should generate labels for each item' do
         ::Author.all.each do |author|
-          expect(output_buffer).to have_tag('form li fieldset ol li label', /#{author.to_label}/)
+          expect(output_buffer).to have_tag('form li fieldset ol li label', :text => /#{author.to_label}/)
           expect(output_buffer).to have_tag("form li fieldset ol li label[@for='project_author_id_#{author.id}']")
         end
       end
@@ -223,7 +223,7 @@ RSpec.describe 'check_boxes input' do
 
         it "should have one item disabled; the specified one" do
           expect(output_buffer).to have_tag("form li fieldset ol li label input[@disabled='disabled']", :count => 1)
-          expect(output_buffer).to have_tag("form li fieldset ol li label[@for='post_author_ids_#{@fred.id}']", /fred/i)
+          expect(output_buffer).to have_tag("form li fieldset ol li label[@for='post_author_ids_#{@fred.id}']", :text => /fred/i)
           expect(output_buffer).to have_tag("form li fieldset ol li label input[@disabled='disabled'][@value='#{@fred.id}']")
         end
       end
@@ -239,9 +239,9 @@ RSpec.describe 'check_boxes input' do
 
         it "should have multiple items disabled; the specified ones" do
           expect(output_buffer).to have_tag("form li fieldset ol li label input[@disabled='disabled']", :count => 2)
-          expect(output_buffer).to have_tag("form li fieldset ol li label[@for='post_author_ids_#{@bob.id}']", /bob/i)
+          expect(output_buffer).to have_tag("form li fieldset ol li label[@for='post_author_ids_#{@bob.id}']", :text => /bob/i)
           expect(output_buffer).to have_tag("form li fieldset ol li label input[@disabled='disabled'][@value='#{@bob.id}']")
-          expect(output_buffer).to have_tag("form li fieldset ol li label[@for='post_author_ids_#{@fred.id}']", /fred/i)
+          expect(output_buffer).to have_tag("form li fieldset ol li label[@for='post_author_ids_#{@fred.id}']", :text => /fred/i)
           expect(output_buffer).to have_tag("form li fieldset ol li label input[@disabled='disabled'][@value='#{@fred.id}']")
         end
       end
@@ -265,7 +265,7 @@ RSpec.describe 'check_boxes input' do
       end
 
       it "should do foo" do
-        expect(output_buffer).to have_tag("legend.label label", /Translated/)
+        expect(output_buffer).to have_tag("legend.label label", :text => /Translated/)
       end
 
     end
@@ -279,7 +279,7 @@ RSpec.describe 'check_boxes input' do
       end
 
       it "should output the correct label title" do
-        expect(output_buffer).to have_tag("legend.label label", /The authors/)
+        expect(output_buffer).to have_tag("legend.label label", :text => /The authors/)
       end
     end
 
@@ -502,7 +502,7 @@ RSpec.describe 'check_boxes input' do
 
     it "should use array items for labels and values" do
       @_collection.each do |post|
-        expect(output_buffer).to have_tag('form li fieldset ol li label', /#{post.first}/)
+        expect(output_buffer).to have_tag('form li fieldset ol li label', :text => /#{post.first}/)
         expect(output_buffer).to have_tag("form li fieldset ol li label[@for='author_post_ids_#{post.last}']")
       end
     end

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -160,8 +160,9 @@ RSpec.describe 'check_boxes input' do
           concat(builder.input(:author_id, :as => :check_boxes, :collection => [["<b>Item 1</b>", 1], ["<b>Item 2</b>", 2]]))
         end)
 
-        expect(output_buffer).to have_tag('form li fieldset ol li label') do |label|
-          expect(label.body).to match /&lt;b&gt;Item [12]&lt;\/b&gt;$/
+        expect(output_buffer).to have_tag('form li fieldset ol li label', text: %r{<b>Item [12]</b>}, count: 2) do |label|
+          expect(label).to have_text('<b>Item 1</b>', count: 1)
+          expect(label).to have_text('<b>Item 2</b>', count: 1)
         end
       end
     end

--- a/spec/inputs/country_input_spec.rb
+++ b/spec/inputs/country_input_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'country input' do
     it 'should generate a label for the input' do
       expect(output_buffer).to have_tag('form li label')
       expect(output_buffer).to have_tag('form li label[@for="post_country"]')
-      expect(output_buffer).to have_tag('form li label', /Country/)
+      expect(output_buffer).to have_tag('form li label', :text => /Country/)
     end
 
     it "should generate a select" do

--- a/spec/inputs/date_select_input_spec.rb
+++ b/spec/inputs/date_select_input_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'date select input' do
     it_should_apply_error_logic_for_input_type(:date_select)
 
     it 'should have a legend and label with the label text inside the fieldset' do
-      expect(output_buffer).to have_tag('form li.date_select fieldset legend.label label', /Publish at/)
+      expect(output_buffer).to have_tag('form li.date_select fieldset legend.label label', :text => /Publish at/)
     end
 
     it 'should associate the legend label with the first select' do
@@ -45,9 +45,9 @@ RSpec.describe 'date select input' do
 
     it 'should have three labels for year, month and day' do
       expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', :count => 3)
-      expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', /year/i)
-      expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', /month/i)
-      expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', /day/i)
+      expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', :text => /year/i)
+      expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', :text => /month/i)
+      expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', :text => /day/i)
     end
 
     it 'should have three selects for year, month and day' do
@@ -112,7 +112,7 @@ RSpec.describe 'date select input' do
         end)
         expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', :count => fields.length)
         fields.each do |f|
-          expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', f == field ? /another #{f} label/i : /#{f}/i)
+          expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', :text => f == field ? /another #{f} label/i : /#{f}/i)
         end
       end
 
@@ -123,7 +123,7 @@ RSpec.describe 'date select input' do
         end)
         expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', :count => fields.length-1)
         fields.each do |f|
-          expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', /#{f}/i) unless field == f
+          expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', :text => /#{f}/i) unless field == f
         end
       end
       

--- a/spec/inputs/datetime_select_input_spec.rb
+++ b/spec/inputs/datetime_select_input_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'datetime select input' do
     it_should_apply_error_logic_for_input_type(:datetime_select)
     
     it 'should have a legend and label with the label text inside the fieldset' do
-      expect(output_buffer).to have_tag('form li.datetime_select fieldset legend.label label', /Publish at/)
+      expect(output_buffer).to have_tag('form li.datetime_select fieldset legend.label label', :text => /Publish at/)
     end
     
     it 'should associate the legend label with the first select' do
@@ -46,11 +46,11 @@ RSpec.describe 'datetime select input' do
 
     it 'should have five labels for year, month and day' do
       expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :count => 5)
-      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', /year/i)
-      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', /month/i)
-      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', /day/i)
-      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', /hour/i)
-      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', /min/i)
+      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :text => /year/i)
+      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :text => /month/i)
+      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :text => /day/i)
+      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :text => /hour/i)
+      expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :text => /min/i)
     end
     
     it 'should have five selects' do
@@ -122,7 +122,7 @@ RSpec.describe 'datetime select input' do
         end)
         expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :count => fields.length)
         fields.each do |f|
-          expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', f == field ? /another #{f} label/i : /#{f}/i)
+          expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :text => f == field ? /another #{f} label/i : /#{f}/i)
         end
       end
       
@@ -133,7 +133,7 @@ RSpec.describe 'datetime select input' do
         end)
         expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :count => fields.length-1)
         fields.each do |f|
-          expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', /#{f}/i) unless field == f
+          expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :text => /#{f}/i) unless field == f
         end
       end
       
@@ -144,7 +144,7 @@ RSpec.describe 'datetime select input' do
         end)
         expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :count => fields.length-1)
         fields.each do |f|
-          expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', /#{f}/i) unless field == f
+          expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :text => /#{f}/i) unless field == f
         end
       end
       

--- a/spec/inputs/label_spec.rb
+++ b/spec/inputs/label_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
     concat(semantic_form_for(@new_post) do |builder|
       builder.input(:title)
     end)
-    expect(output_buffer).to have_tag('label', /Title/)
+    expect(output_buffer).to have_tag('label', :text => /Title/)
   end
   
   it 'should use i18n instead of the method name when method given as a String' do
@@ -46,7 +46,7 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
         builder.input("title")
       end)
       ::I18n.backend.store_translations :en, { :formtastic => { :labels => { :post => { :title => nil } } } }
-      expect(output_buffer).to have_tag('label', /I18n title/)
+      expect(output_buffer).to have_tag('label', :text => /I18n title/)
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
     concat(semantic_form_for(@new_post) do |builder|
       builder.input(:publish_at)
     end)
-    expect(output_buffer).to have_tag('label', /Publish at/)
+    expect(output_buffer).to have_tag('label', :text => /Publish at/)
   end
 
   describe 'when required is given' do
@@ -73,7 +73,7 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
           concat(builder.input(:author_id, :as => :check_boxes, :collection => [:a, :b, :c], :member_value => :to_s, :member_label => proc {|f| ('Label_%s' % [f])}))
         end)
       end
-      expect(output_buffer).to have_tag('form li fieldset ol li label', /Label_[abc]/, :count => 3)
+      expect(output_buffer).to have_tag('form li fieldset ol li label', :text => /Label_[abc]/, :count => 3)
     end
 
     it 'should use a supplied value_method for simple collections' do
@@ -93,14 +93,14 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
       concat(semantic_form_for(@new_post) do |builder|
         builder.input(:title, :label => 'My label')
       end)
-      expect(output_buffer).to have_tag('label', /My label/)
+      expect(output_buffer).to have_tag('label', :text => /My label/)
     end
     
     it 'should allow the text to be given as label option for date fields' do
       concat(semantic_form_for(@new_post) do |builder|
         builder.input(:publish_at, :label => 'My other label')
       end)
-      expect(output_buffer).to have_tag('label', /My other label/)
+      expect(output_buffer).to have_tag('label', :text => /My other label/)
     end
 
     it 'should return nil if label is false' do
@@ -132,7 +132,7 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
       concat(semantic_form_for(@new_post) do |builder|
         builder.input(:title, :label => '<b>My label</b>')
       end)
-      expect(output_buffer).to have_tag("label b", "My label")
+      expect(output_buffer).to have_tag("label b", :text => "My label")
     end
 
     it 'should not html escape the label string for html_safe strings' do

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'radio input' do
 
     it 'should generate a legend containing a label with text for the input' do
       expect(output_buffer).to have_tag('form li fieldset legend.label label')
-      expect(output_buffer).to have_tag('form li fieldset legend.label label', /Author/)
+      expect(output_buffer).to have_tag('form li fieldset legend.label label', :text => /Author/)
     end
 
     it 'should not link the label within the legend to any input' do
@@ -118,7 +118,7 @@ RSpec.describe 'radio input' do
       end
 
       it 'should generate a fieldset with legend' do
-        expect(output_buffer).to have_tag('form li fieldset legend', /Author/)
+        expect(output_buffer).to have_tag('form li fieldset legend', :text => /Author/)
       end
 
       it 'should generate an li tag for each item in the collection' do
@@ -127,7 +127,7 @@ RSpec.describe 'radio input' do
 
       it 'should generate labels for each item' do
         ::Author.all.each do |author|
-          expect(output_buffer).to have_tag('form li fieldset ol li label', /#{author.to_label}/)
+          expect(output_buffer).to have_tag('form li fieldset ol li label', :text => /#{author.to_label}/)
           expect(output_buffer).to have_tag("form li fieldset ol li label[@for='project_author_id_#{author.id}']")
         end
       end
@@ -170,7 +170,7 @@ RSpec.describe 'radio input' do
       expect(output_buffer).to have_tag("form li input[@name='post[status]'][@type='radio']", :count => @new_post.class.statuses.count)
       @new_post.class.statuses.each do |label, value|
         expect(output_buffer).to have_tag("form li input[@value='#{label}']")
-        expect(output_buffer).to have_tag("form li label", /#{label.humanize}/)
+        expect(output_buffer).to have_tag("form li label", :text => /#{label.humanize}/)
       end
     end
 
@@ -198,7 +198,7 @@ RSpec.describe 'radio input' do
     end
 
     it "should do foo" do
-      expect(output_buffer).to have_tag("legend.label label", /Translated/)
+      expect(output_buffer).to have_tag("legend.label label", :text => /Translated/)
     end
 
   end
@@ -212,7 +212,7 @@ RSpec.describe 'radio input' do
     end
 
     it "should output the correct label title" do
-      expect(output_buffer).to have_tag("legend.label label", /The authors/)
+      expect(output_buffer).to have_tag("legend.label label", :text => /The authors/)
     end
   end
 
@@ -301,9 +301,9 @@ RSpec.describe 'radio input' do
     end
 
     it 'should output the correct labels' do
-      expect(output_buffer).to have_tag("li.choice label", /1/)
-      expect(output_buffer).to have_tag("li.choice label", /2/)
-      expect(output_buffer).to have_tag("li.choice label", /3/)
+      expect(output_buffer).to have_tag("li.choice label", :text => /1/)
+      expect(output_buffer).to have_tag("li.choice label", :text => /2/)
+      expect(output_buffer).to have_tag("li.choice label", :text => /3/)
     end
   end
 
@@ -318,9 +318,9 @@ RSpec.describe 'radio input' do
     end
 
     it 'should output the correct labels' do
-      expect(output_buffer).to have_tag("li.choice label", /A/)
-      expect(output_buffer).to have_tag("li.choice label", /B/)
-      expect(output_buffer).to have_tag("li.choice label", /C/)
+      expect(output_buffer).to have_tag("li.choice label", :text => /A/)
+      expect(output_buffer).to have_tag("li.choice label", :text => /B/)
+      expect(output_buffer).to have_tag("li.choice label", :text => /C/)
     end
   end
 

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -136,9 +136,7 @@ RSpec.describe 'radio input' do
         concat(semantic_form_for(:project, :url => 'http://test.host') do |builder|
           concat(builder.input(:author_id, :as => :radio, :collection => [["<b>Item 1</b>", 1], ["<b>Item 2</b>", 2]]))
         end)
-        expect(output_buffer).to have_tag('form li fieldset ol li label') do |label|
-          expect(label.body).to match /&lt;b&gt;Item [12]&lt;\/b&gt;$/
-        end
+        expect(output_buffer).to have_tag('form li fieldset ol li label', text: %r{<b>Item [12]</b>}, count: 2)
       end
 
       it 'should generate inputs for each item' do

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe 'select input' do
 
       it 'should have a option for each key and/or value' do
         @array_with_values.each do |v|
-          expect(output_buffer).to have_tag("form li select option[@value='#{v}']", /^#{v}$/)
+          expect(output_buffer).to have_tag("form li select option[@value='#{v}']", :text => /^#{v}$/)
         end
         @array_with_keys_and_values.each do |v|
-          expect(output_buffer).to have_tag("form li select option[@value='#{v.second}']", /^#{v.first}$/)
+          expect(output_buffer).to have_tag("form li select option[@value='#{v.second}']", :text => /^#{v.first}$/)
         end
       end
     end
@@ -43,10 +43,10 @@ RSpec.describe 'select input' do
 
       it 'should have a option for each key and/or value' do
         @set_with_values.each do |v|
-          expect(output_buffer).to have_tag("form li select option[@value='#{v}']", /^#{v}$/)
+          expect(output_buffer).to have_tag("form li select option[@value='#{v}']", :text => /^#{v}$/)
         end
         @set_with_keys_and_values.each do |v|
-          expect(output_buffer).to have_tag("form li select option[@value='#{v.second}']", /^#{v.first}$/)
+          expect(output_buffer).to have_tag("form li select option[@value='#{v.second}']", :text => /^#{v.first}$/)
         end
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe 'select input' do
 
       it 'should have an option for each value' do
         @range_with_values.each do |v|
-          expect(output_buffer).to have_tag("form li select option[@value='#{v}']", /^#{v}$/)
+          expect(output_buffer).to have_tag("form li select option[@value='#{v}']", :text => /^#{v}$/)
         end
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe 'select input' do
 
       it 'should render select options using provided HTML string' do
         2.times do |v|
-          expect(output_buffer).to have_tag("form li select option[@value='#{v}']", /^#{v}$/)
+          expect(output_buffer).to have_tag("form li select option[@value='#{v}']", :text => /^#{v}$/)
         end
       end
     end
@@ -125,8 +125,8 @@ RSpec.describe 'select input' do
       end
 
       it 'should render a select with at least options: true/false' do
-        expect(output_buffer).to have_tag("form li select option[@value='true']", /^Yes$/)
-        expect(output_buffer).to have_tag("form li select option[@value='false']", /^No$/)
+        expect(output_buffer).to have_tag("form li select option[@value='true']", :text => /^Yes$/)
+        expect(output_buffer).to have_tag("form li select option[@value='false']", :text => /^No$/)
       end
     end
 
@@ -145,8 +145,8 @@ RSpec.describe 'select input' do
       end
 
       it 'should render a select with at least options: true/false' do
-        expect(output_buffer).to have_tag("form li select option[@value='true']", /#{@boolean_select_labels[:yes]}/)
-        expect(output_buffer).to have_tag("form li select option[@value='false']", /#{@boolean_select_labels[:no]}/)
+        expect(output_buffer).to have_tag("form li select option[@value='true']", :text => /#{@boolean_select_labels[:yes]}/)
+        expect(output_buffer).to have_tag("form li select option[@value='false']", :text => /#{@boolean_select_labels[:no]}/)
       end
     end
   end
@@ -202,7 +202,7 @@ RSpec.describe 'select input' do
       it 'should have a select option for each defined enum status' do
         expect(output_buffer).to have_tag("form li select[@name='post[status]'] option", :count => @new_post.class.statuses.count + 1)
         @new_post.class.statuses.each do |label, value|
-          expect(output_buffer).to have_tag("form li select option[@value='#{label}']", /#{label.humanize}/)
+          expect(output_buffer).to have_tag("form li select option[@value='#{label}']", :text => /#{label.humanize}/)
         end
       end
 
@@ -270,7 +270,7 @@ RSpec.describe 'select input' do
     it 'should have a select option for each Author' do
       expect(output_buffer).to have_tag("form li select[@name='post[author_id]'] option", :count => ::Author.all.size + 1)
       ::Author.all.each do |author|
-        expect(output_buffer).to have_tag("form li select option[@value='#{author.id}']", /#{author.to_label}/)
+        expect(output_buffer).to have_tag("form li select option[@value='#{author.id}']", :text => /#{author.to_label}/)
       end
     end
 
@@ -344,7 +344,7 @@ RSpec.describe 'select input' do
     it 'should have a select option for each Post' do
       expect(output_buffer).to have_tag('form li select option', :count => ::Post.all.size)
       ::Post.all.each do |post|
-        expect(output_buffer).to have_tag("form li select option[@value='#{post.id}']", /#{post.to_label}/)
+        expect(output_buffer).to have_tag("form li select option[@value='#{post.id}']", :text => /#{post.to_label}/)
       end
     end
 
@@ -400,7 +400,7 @@ RSpec.describe 'select input' do
     it 'should have a select option for each Author' do
       expect(output_buffer).to have_tag('form li select option', :count => ::Author.all.size)
       ::Author.all.each do |author|
-        expect(output_buffer).to have_tag("form li select option[@value='#{author.id}']", /#{author.to_label}/)
+        expect(output_buffer).to have_tag("form li select option[@value='#{author.id}']", :text => /#{author.to_label}/)
       end
     end
 
@@ -438,7 +438,7 @@ RSpec.describe 'select input' do
     end
 
     it 'should have a select with prompt' do
-      expect(output_buffer).to have_tag("form li select option[@value='']", /choose author/, :count => 1)
+      expect(output_buffer).to have_tag("form li select option[@value='']", :text => /choose author/, :count => 1)
     end
 
     it 'should not have a second blank select option' do
@@ -454,7 +454,7 @@ RSpec.describe 'select input' do
     end
 
     it 'should generate label' do
-      expect(output_buffer).to have_tag('form li label', /Author/)
+      expect(output_buffer).to have_tag('form li label', :text => /Author/)
       expect(output_buffer).to have_tag("form li label[@for='project_author']")
     end
 
@@ -465,7 +465,7 @@ RSpec.describe 'select input' do
 
     it 'should generate an option to each item' do
       ::Author.all.each do |author|
-        expect(output_buffer).to have_tag("form li select option[@value='#{author.id}']", /#{author.to_label}/)
+        expect(output_buffer).to have_tag("form li select option[@value='#{author.id}']", :text => /#{author.to_label}/)
       end
     end
   end

--- a/spec/inputs/time_select_input_spec.rb
+++ b/spec/inputs/time_select_input_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'time select input' do
       it_should_apply_error_logic_for_input_type(:time_select)
 
       it 'should have a legend and label with the label text inside the fieldset' do
-        expect(output_buffer).to have_tag('form li.time_select fieldset legend.label label', /Publish at/)
+        expect(output_buffer).to have_tag('form li.time_select fieldset legend.label label', :text => /Publish at/)
       end
 
       it 'should associate the legend label with the first select' do
@@ -94,8 +94,8 @@ RSpec.describe 'time select input' do
 
       it 'should have five labels for hour and minute' do
         expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :count => 2)
-        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', /hour/i)
-        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', /minute/i)
+        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :text => /hour/i)
+        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :text => /minute/i)
       end
 
       it 'should have two selects for hour and minute' do
@@ -112,9 +112,9 @@ RSpec.describe 'time select input' do
 
       it 'should have five labels for hour and minute' do
         expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :count => 3)
-        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', /hour/i)
-        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', /minute/i)
-        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', /second/i)
+        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :text => /hour/i)
+        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :text => /minute/i)
+        expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :text => /second/i)
       end
 
       it 'should have three selects for hour, minute and seconds' do
@@ -140,7 +140,7 @@ RSpec.describe 'time select input' do
         end)
         expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :count => fields.length)
         fields.each do |f|
-          expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', f == field ? /another #{f} label/i : /#{f}/i)
+          expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :text => f == field ? /another #{f} label/i : /#{f}/i)
         end
       end
 
@@ -151,7 +151,7 @@ RSpec.describe 'time select input' do
         end)
         expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :count => fields.length-1)
         fields.each do |f|
-          expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', /#{f}/i) unless field == f
+          expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :text => /#{f}/i) unless field == f
         end
       end
       
@@ -162,7 +162,7 @@ RSpec.describe 'time select input' do
         end)
         expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :count => fields.length-1)
         fields.each do |f|
-          expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', /#{f}/i) unless field == f
+          expect(output_buffer).to have_tag('form li.time_select fieldset ol li label', :text => /#{f}/i) unless field == f
         end
       end
 

--- a/spec/inputs/time_zone_input_spec.rb
+++ b/spec/inputs/time_zone_input_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'time_zone input' do
   it 'should generate a label for the input' do
     expect(output_buffer).to have_tag('form li label')
     expect(output_buffer).to have_tag('form li label[@for="post_time_zone"]')
-    expect(output_buffer).to have_tag('form li label', /Time zone/)
+    expect(output_buffer).to have_tag('form li label', :text => /Time zone/)
   end
 
   it "should generate a select" do
@@ -93,7 +93,7 @@ RSpec.describe 'time_zone input' do
     it 'should generate labels' do
       expect(output_buffer).to have_tag('form li label')
       expect(output_buffer).to have_tag('form li label[@for="project_time_zone"]')
-      expect(output_buffer).to have_tag('form li label', /Time zone/)
+      expect(output_buffer).to have_tag('form li label', :text => /Time zone/)
     end
 
     it 'should generate select inputs' do

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -46,7 +46,7 @@ module CustomMacros
 
     def it_should_have_label_with_text(string_or_regex)
       it "should have a label with text '#{string_or_regex}'" do
-        expect(output_buffer).to have_tag("form li label", string_or_regex)
+        expect(output_buffer).to have_tag("form li label", :text => string_or_regex)
       end
     end
 
@@ -310,7 +310,7 @@ module CustomMacros
             end)
 
             @categories.each do |value|
-              expect(output_buffer).to have_tag("form li.#{as}", /#{value}/)
+              expect(output_buffer).to have_tag("form li.#{as}", :text => /#{value}/)
               expect(output_buffer).to have_tag("form li.#{as} #{countable}[@value='#{value}']")
             end
           end
@@ -343,7 +343,7 @@ module CustomMacros
             end)
 
             @categories.each do |label, value|
-              expect(output_buffer).to have_tag("form li.#{as}", /#{label}/)
+              expect(output_buffer).to have_tag("form li.#{as}", :text => /#{label}/)
               expect(output_buffer).to have_tag("form li.#{as} #{countable}[@value='#{value}']")
             end
           end
@@ -361,7 +361,7 @@ module CustomMacros
 
             @categories.each do |text, value|
               label = as == :select ? :option : :label
-              expect(output_buffer).to have_tag("form li.#{as} #{label}", /#{text}/i)
+              expect(output_buffer).to have_tag("form li.#{as} #{label}", :text => /#{text}/i)
               expect(output_buffer).to have_tag("form li.#{as} #{countable}[@value='#{value.to_s}']")
               expect(output_buffer).to have_tag("form li.#{as} #{countable}#post_category_name_#{value.to_s}") if as == :radio
             end
@@ -397,7 +397,7 @@ module CustomMacros
 
             @categories.each do |value|
               label = as == :select ? :option : :label
-              expect(output_buffer).to have_tag("form li.#{as} #{label}", /#{value}/i)
+              expect(output_buffer).to have_tag("form li.#{as} #{label}", :text => /#{value}/i)
               expect(output_buffer).to have_tag("form li.#{as} #{countable}[@value='#{value.to_s}']")
             end
           end
@@ -414,7 +414,7 @@ module CustomMacros
             end)
 
             @categories.each do |label, value|
-              expect(output_buffer).to have_tag("form li.#{as}", /#{label}/)
+              expect(output_buffer).to have_tag("form li.#{as}", :text => /#{label}/)
               expect(output_buffer).to have_tag("form li.#{as} #{countable}[@value='#{value}']")
             end
           end
@@ -434,7 +434,7 @@ module CustomMacros
 
             it 'should have options with text content from the specified method' do
               ::Author.all.each do |author|
-                expect(output_buffer).to have_tag("form li.#{as}", /#{author.login}/)
+                expect(output_buffer).to have_tag("form li.#{as}", :text => /#{author.login}/)
               end
             end
           end
@@ -450,7 +450,7 @@ module CustomMacros
 
             it 'should have options with the proc applied to each' do
               ::Author.all.each do |author|
-                expect(output_buffer).to have_tag("form li.#{as}", /#{author.login.reverse}/)
+                expect(output_buffer).to have_tag("form li.#{as}", :text => /#{author.login.reverse}/)
               end
             end
           end
@@ -469,7 +469,7 @@ module CustomMacros
 
             it 'should have options with the proc applied to each' do
               ::Author.all.each do |author|
-                expect(output_buffer).to have_tag("form li.#{as}", /#{author.login.reverse}/)
+                expect(output_buffer).to have_tag("form li.#{as}", :text => /#{author.login.reverse}/)
               end
             end
           end
@@ -492,7 +492,7 @@ module CustomMacros
 
               it "should render the options with #{label_method} as the label" do
                 ::Author.all.each do |author|
-                  expect(output_buffer).to have_tag("form li.#{as}", /The Label Text/)
+                  expect(output_buffer).to have_tag("form li.#{as}", :text => /The Label Text/)
                 end
               end
             end

--- a/spec/support/test_environment.rb
+++ b/spec/support/test_environment.rb
@@ -44,8 +44,3 @@ end
 FormtasticTest::Application.initialize!
 
 require 'rspec/rails'
-
-# Quick hack to avoid the 'Spec' deprecation warnings from rspec_tag_matchers
-module Spec
-  include RSpec
-end

--- a/spec/support/test_environment.rb
+++ b/spec/support/test_environment.rb
@@ -1,10 +1,11 @@
 # encoding: utf-8
 require 'rspec/core'
-require 'rspec_tag_matchers'
+
+require 'rspec-dom-testing'
 
 RSpec.configure do |config|
-  config.include RspecTagMatchers
   config.include CustomMacros
+  config.include RSpec::Dom::Testing::Matchers
   config.mock_with :rspec
 
   # rspec-rails 3 will no longer automatically infer an example group's spec type


### PR DESCRIPTION
`rspec_tag_matchers` was released in 2009 and haven't updated since.

This builds on #1206 and replaces the outdated gem with implementation based on rails `assert_select`. 
Also it fixes the `has_tag` calls with 2 parameters to 1 parameter and options hash. 

Depends on #1206.

I extracted the implementation into a new gem: https://github.com/mikz/rspec-dom-testing
