### PR TITLE
drop support for ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - vendor/bundle
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.8
   - 2.2.4
@@ -24,11 +23,8 @@ script:
  - script/integration.sh
 matrix:
   exclude:
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.1.8
       gemfile: gemfiles/rails_edge.gemfile
   allow_failures:
-    - rvm: 1.9.3

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Formtastic is a Rails FormBuilder DSL (with some other goodies) to make it far e
 
 ## Compatibility
 
-* Formtastic 4 will require Rails 4.1
+* Formtastic 4 will require Rails 4.1 and Ruby 2.0 minimum
 * Formtastic 3 requires Rails 3.2.13 minimum
 * Formtastic 2 requires Rails 3
 * Formtastic, much like Rails, is very ActiveRecord-centric. Many are successfully using other ActiveModel-like ORMs and objects (DataMapper, MongoMapper, Mongoid, Authlogic, Devise...) but we're not guaranteeing full compatibility at this stage. Patches are welcome!

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.textile"]
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.rubygems_version = %q{1.3.6}
 


### PR DESCRIPTION
EOL was more than a year ago
https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/

the travis build is failing anyway, because it can't install some gems (requiring >= 2.0)