### PR TITLE
Apply symbol value like string

### DIFF
--- a/lib/formtastic/inputs/check_boxes_input.rb
+++ b/lib/formtastic/inputs/check_boxes_input.rb
@@ -138,11 +138,11 @@ module Formtastic
       end
 
       def checked?(value)
-        selected_values.include?(value)
+        selected_values.include?(value.is_a?(Symbol) ? value.to_s : value)
       end
 
       def disabled?(value)
-        disabled_values.include?(value)
+        disabled_values.include?(value.is_a?(Symbol) ? value.to_s : value)
       end
 
       def selected_values


### PR DESCRIPTION
Apply symbols for checkboxes, like strings. It makes interface more clear, and prevent from some night errors :)
