### PR TITLE
Check boxes control is not saved as empty array if no boxes were checked (master)

### DIFF
--- a/lib/formtastic/inputs/check_boxes_input.rb
+++ b/lib/formtastic/inputs/check_boxes_input.rb
@@ -99,7 +99,7 @@ module Formtastic
       end
 
       def hidden_field_for_all
-        if hidden_fields?
+        if hidden_fields_for_every?
           ''
         else
           options = {}
@@ -109,7 +109,7 @@ module Formtastic
         end
       end
 
-      def hidden_fields?
+      def hidden_fields_for_every?
         options[:hidden_fields]
       end
 
@@ -170,7 +170,7 @@ module Formtastic
       protected
 
       def checkbox_input(choice)
-        if hidden_fields?
+        if hidden_fields_for_every?
           check_box_with_hidden_input(choice)
         else
           check_box_without_hidden_input(choice)

--- a/lib/formtastic/inputs/check_boxes_input.rb
+++ b/lib/formtastic/inputs/check_boxes_input.rb
@@ -100,12 +100,12 @@ module Formtastic
 
       def hidden_field_for_all
         if hidden_fields?
+          ''
+        else
           options = {}
           options[:class] = [method.to_s.singularize, 'default'].join('_') if value_as_class?
           options[:id] = [object_name, method, 'none'].join('_')
           template.hidden_field_tag(input_name, '', options)
-        else
-          ''
         end
       end
 

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'check_boxes input' do
     end
 
     it 'should render one hidden input for each choice outside the ol' do
-      output_buffer.to have_tag("form li fieldset > input[@type='hidden']", :count => 1)
+      expect(output_buffer).to have_tag("form li fieldset > input[@type='hidden']", :count => 1)
     end
 
     describe "each choice" do
@@ -91,11 +91,11 @@ RSpec.describe 'check_boxes input' do
       end
 
       it 'should have a hidden field with an empty array value for the collection to allow clearing of all checkboxes' do
-        output_buffer.to have_tag("form li fieldset > input[@type=hidden][@name='author[post_ids][]'][@value='']", :count => 1)
+        expect(output_buffer).to have_tag("form li fieldset > input[@type=hidden][@name='author[post_ids][]'][@value='']", :count => 1)
       end
 
       it 'the hidden field with an empty array value should be followed by the ol' do
-        output_buffer.to have_tag("form li fieldset > input[@type=hidden][@name='author[post_ids][]'][@value=''] + ol", :count => 1)
+        expect(output_buffer).to have_tag("form li fieldset > input[@type=hidden][@name='author[post_ids][]'][@value=''] + ol", :count => 1)
       end
 
       it 'should not have a hidden field with an empty string value for the collection' do

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe 'check_boxes input' do
       expect(output_buffer).not_to have_tag("form li fieldset ol li input[@type='hidden']")
     end
 
-    it 'should not render hidden input for each choice outside the ol' do
-      expect(output_buffer).not_to have_tag("form li fieldset > input[@type='hidden']")
+    it 'should render one hidden input for each choice outside the ol' do
+      output_buffer.to have_tag("form li fieldset > input[@type='hidden']", :count => 1)
     end
 
     describe "each choice" do
@@ -90,12 +90,12 @@ RSpec.describe 'check_boxes input' do
         end
       end
 
-      it 'should not have a hidden field with an empty array value for the collection to allow clearing of all checkboxes' do
-        expect(output_buffer).not_to have_tag("form li fieldset > input[@type=hidden][@name='author[post_ids][]'][@value='']")
+      it 'should have a hidden field with an empty array value for the collection to allow clearing of all checkboxes' do
+        output_buffer.to have_tag("form li fieldset > input[@type=hidden][@name='author[post_ids][]'][@value='']", :count => 1)
       end
 
-      it 'should not have a hidden field with an empty array value followed by the ol' do
-        expect(output_buffer).not_to have_tag("form li fieldset > input[@type=hidden][@name='author[post_ids][]'][@value=''] + ol")
+      it 'the hidden field with an empty array value should be followed by the ol' do
+        output_buffer.to have_tag("form li fieldset > input[@type=hidden][@name='author[post_ids][]'][@value=''] + ol", :count => 1)
       end
 
       it 'should not have a hidden field with an empty string value for the collection' do


### PR DESCRIPTION
Undo merge #1190, there was no bug there

The issue #1189 however stands valid: `hidden_fields?` seems poorly named. Maybe rename it `hidden_fields_for_every?` to oppose `hidden_field_for_all`