### PR TITLE
Default input type should be text for json, jsonb, citext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Added mapping hstore column to text input (#1203)
   * Added support for Rails 5 Attributes API (#1188)
   * Changed required Ruby version to >= 2.0 (#1210)
+  * Default to input types text for json & jsonb, string for citext columns (#1229)
 
 ## 3.1.2
 

--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -283,8 +283,10 @@ module Formtastic
             return :time_select
           when :date
             return :date_select
-          when :hstore
+          when :hstore, :json, :jsonb
             return :text
+          when :citext
+            return :string
           end
 
           # Try look for hints in options hash. Quite common senario: Enum keys stored as string in the database.

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -482,8 +482,10 @@ RSpec.describe 'with input class finder' do
           expect(default_input_type(:date)).to eq(:date_select)
         end
 
-        it 'should default to :text for :hstore column types' do
+        it 'should default to :text for :hstore, :json and :jsonb column types' do
           expect(default_input_type(:hstore)).to eq(:text)
+          expect(default_input_type(:json)).to eq(:text)
+          expect(default_input_type(:jsonb)).to eq(:text)
         end
 
         it 'should default to :datetime_select for :datetime and :timestamp column types' do
@@ -501,6 +503,10 @@ RSpec.describe 'with input class finder' do
 
         it 'should default to :string for :string column types' do
           expect(default_input_type(:string)).to eq(:string)
+        end
+
+        it 'should default to :string for :citext column types' do
+          expect(default_input_type(:citext)).to eq(:string)
         end
 
         it 'should default to :number for :integer, :float and :decimal column types' do


### PR DESCRIPTION
Currently these just throw an exception like "No input found for <type>." This is in the same spirit as https://github.com/justinfrench/formtastic/pull/1203, which is for `hstore`, a similar type to `json`. `citext` is a simply case-insensitive version of `text`.
