### PR TITLE
[travis] update appraisals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,4 @@ matrix:
       gemfile: gemfiles/rails_5.0.gemfile
   allow_failures:
     - gemfile: gemfiles/rails_edge.gemfile
+    - rvm: 2.0.0

--- a/Appraisals
+++ b/Appraisals
@@ -1,14 +1,16 @@
 appraise 'rails-4.1' do
   gem 'rails', '~>4.1.0'
+  gem 'nokogiri', '~>1.6.8', platform: :mri_20
 end
 
 appraise 'rails-4.2' do
-  gem 'rails', '~>4.2.0.beta4'
+  gem 'rails', '~>4.2.0'
+  gem 'nokogiri', '~>1.6.8', platform: :mri_20
 end
 
 appraise 'rails-5.0' do
-  gem 'rails', '> 5.0.0.rc', '< 5.1'
-  gem 'rspec-rails', '> 3.5.0.beta', '< 3.6'
+  gem 'rails', '~> 5.0.1'
+  gem 'rspec-rails', '~> 3.5'
 end
 
 appraise 'rails-edge' do

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<colored>, ["~> 1.2"])
   s.add_development_dependency(%q<tzinfo>)
   s.add_development_dependency(%q<ammeter>, ["~> 1.1.3"])
-  s.add_development_dependency(%q<appraisal>, ["~> 1.0"])
+  s.add_development_dependency(%q<appraisal>, ["~> 2.1"])
   s.add_development_dependency(%q<rake>)
   s.add_development_dependency(%q<activemodel>, [">= 3.2.13"])
 end

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~>4.1.0"
+gem "nokogiri", "~>1.6.8", :platform => :mri_20
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~>4.2.0.beta4"
+gem "rails", "~>4.2.0"
+gem "nokogiri", "~>1.6.8", :platform => :mri_20
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "> 5.0.0.rc", "< 5.1"
-gem "rspec-rails", "> 3.5.0.beta", "< 3.6"
+gem "rails", "~> 5.0.1"
+gem "rspec-rails", "~> 3.5"
 
 gemspec :path => "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", :git => "git://github.com/rails/rails.git"
+gem "rails", :github => "rails/rails"
 gem "rack", :github => "rack/rack"
 gem "i18n", :github => "svenfuchs/i18n"
 gem "arel", :github => "rails/arel"


### PR DESCRIPTION
to correctly work with Ruby 2.0

but given that `rails new` fails on Ruby 2.0, just add it to allowed failures