### PR TITLE
Backport Ruby 2.4 support to 3.1 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.0
+  - 2.4.0
 gemfile:
   - gemfiles/rails_3.2.gemfile
   - gemfiles/rails_4.gemfile
@@ -26,6 +27,14 @@ matrix:
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.1.8
       gemfile: gemfiles/rails_edge.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails_5.0.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rails_5.0.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails_4.1.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails_4.2.gemfile
   allow_failures:
     - gemfile: gemfiles/rails_edge.gemfile
     - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ gemfile:
   - gemfiles/rails_4.0.4.gemfile
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
+  - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_edge.gemfile
 env:
-before_install:
-  - gem install bundler --version 1.11.2
+before_install: "gem install bundler --version 1.14.4"
 script: "bundle exec rake spec"
 matrix:
   exclude:
@@ -35,6 +35,12 @@ matrix:
       gemfile: gemfiles/rails_4.1.gemfile
     - rvm: 2.4.0
       gemfile: gemfiles/rails_4.2.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails_3.2.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails_4.0.4.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails_4.gemfile
   allow_failures:
     - gemfile: gemfiles/rails_edge.gemfile
     - rvm: 1.9.3

--- a/Appraisals
+++ b/Appraisals
@@ -1,15 +1,18 @@
 appraise 'rails-3.2' do
   gem 'rails', '~> 3.2.0'
   gem 'test-unit-minitest', :platform => [:ruby_22, :ruby_23]
+  gem 'nokogiri', '~>1.6.8', platform: :mri_20
 end
 
 appraise 'rails-4' do
   gem 'rails', '~> 4.0.0'
+  gem 'nokogiri', '~>1.6.8', platform: :mri_20
 end
 
 # Special case for a change in I18n
 appraise 'rails-4.0.4' do
   gem 'rails', '4.0.4'
+  gem 'nokogiri', '~>1.6.8', platform: :mri_20
 end
 
 appraise 'rails-4.1' do

--- a/Appraisals
+++ b/Appraisals
@@ -14,20 +14,27 @@ end
 
 appraise 'rails-4.1' do
   gem 'rails', '~>4.1.0'
+  gem 'nokogiri', '~>1.6.8', platform: :mri_20
 end
 
 appraise 'rails-4.2' do
-  gem 'rails', '~>4.2.0.beta4'
+  gem 'rails', '~>4.2.0'
+  gem 'nokogiri', '~>1.6.8', platform: :mri_20
+end
+
+appraise 'rails-5.0' do
+  gem 'rails', '~> 5.0.1'
+  gem 'rspec-rails', '~> 3.5'
 end
 
 appraise 'rails-edge' do
-  gem 'rails', :git => 'git://github.com/rails/rails.git'
-  gem 'rack', :github => 'rack/rack'
-  gem 'i18n', :github => 'svenfuchs/i18n'
-  gem 'arel', :github => 'rails/arel'
-  gem 'rspec-rails', :github => 'rspec/rspec-rails'
-  gem 'rspec-mocks', :github => 'rspec/rspec-mocks'
-  gem 'rspec-support', :github => 'rspec/rspec-support'
-  gem 'rspec-core', :github => 'rspec/rspec-core'
-  gem 'rspec-expectations', :github => 'rspec/rspec-expectations'
+  gem 'rails', github: 'rails/rails'
+  gem 'rack', github: 'rack/rack'
+  gem 'i18n', github: 'svenfuchs/i18n'
+  gem 'arel', github: 'rails/arel'
+  gem 'rspec-rails', github: 'rspec/rspec-rails'
+  gem 'rspec-mocks', github: 'rspec/rspec-mocks'
+  gem 'rspec-support', github: 'rspec/rspec-support'
+  gem 'rspec-core', github: 'rspec/rspec-core'
+  gem 'rspec-expectations', github: 'rspec/rspec-expectations'
 end

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.1.5
+  * Backport use Integer instead of Fixnum for Ruby 2.4 support (#1235, #1243)
+
 3.1.4
   * Performance improvements (#1174)
   * Added priority time zones configuration (#1172)

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<tzinfo>)
   s.add_development_dependency(%q<ammeter>, ["~> 1.1.3"])
   s.add_development_dependency(%q<appraisal>, ["~> 2.1"])
-  s.add_development_dependency(%q<rake>)
+  s.add_development_dependency(%q<rake>, ["< 12"])
   s.add_development_dependency(%q<activemodel>, [">= 3.2.13"])
 end

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<colored>, ["~> 1.2"])
   s.add_development_dependency(%q<tzinfo>)
   s.add_development_dependency(%q<ammeter>, ["~> 1.1.3"])
-  s.add_development_dependency(%q<appraisal>, ["~> 1.0"])
+  s.add_development_dependency(%q<appraisal>, ["~> 2.1"])
   s.add_development_dependency(%q<rake>)
   s.add_development_dependency(%q<activemodel>, [">= 3.2.13"])
 end

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 3.2.0"
 gem "test-unit-minitest", :platform => [:ruby_22, :ruby_23]
+gem "nokogiri", "~>1.6.8", :platform => :mri_20
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~>4.1.0"
+gem "nokogiri", "~>1.6.8", :platform => :mri_20
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~>4.2.0.beta4"
+gem "rails", "~>4.2.0"
+gem "nokogiri", "~>1.6.8", :platform => :mri_20
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.0.0"
+gem "nokogiri", "~>1.6.8", :platform => :mri_20
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "4.0.4"
-gem "nokogiri", "~>1.6.8", :platform => :mri_20
+gem "rails", "~> 5.0.1"
+gem "rspec-rails", "~> 3.5"
 
 gemspec :path => "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", :git => "git://github.com/rails/rails.git"
+gem "rails", :github => "rails/rails"
 gem "rack", :github => "rack/rack"
 gem "i18n", :github => "svenfuchs/i18n"
 gem "arel", :github => "rails/arel"

--- a/lib/formtastic/helpers/fieldset_wrapper.rb
+++ b/lib/formtastic/helpers/fieldset_wrapper.rb
@@ -69,7 +69,7 @@ module Formtastic
 
         # TODO: One of the tests produces a scenario where duck is "0" and the test looks for a "1"
         # in the legend, so if we have a number, return it with a +1 until we can verify this scenario.
-        return duck + 1 if duck.is_a?(Fixnum)
+        return duck + 1 if duck.is_a?(Integer)
 
         # First try to extract key from duck Hash, then try child
         (duck[key] || duck[child]).to_i + 1

--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -50,9 +50,9 @@ module Formtastic
           # Return if we have a plain string
           return raw_collection if raw_collection.is_a?(String)
 
-          # Return if we have an Array of strings, fixnums or arrays
+          # Return if we have an Array of strings, integers or arrays
           return raw_collection if (raw_collection.instance_of?(Array) || raw_collection.instance_of?(Range)) &&
-                               [Array, Fixnum, String].include?(raw_collection.first.class) &&
+                               ([Array, String].include?(raw_collection.first.class) || raw_collection.first.is_a?(Integer)) &&
                                !(options.include?(:member_label) || options.include?(:member_value))
 
           raw_collection.map { |o| [send_or_call(label_method, o), send_or_call(value_method, o)] }


### PR DESCRIPTION
Integer instead of Fixnum for Ruby 2.4

closes https://github.com/justinfrench/formtastic/issues/1243

@justinfrench I'll need you to push the release to rubygems. I can prepare the version bump, but I don't have push rights to rubygems.