### PR TITLE
Allow symbols for numericality options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Added support for Rails 5 Attributes API (#1188)
   * Changed required Ruby version to >= 2.0 (#1210)
   * Default to input types text for json & jsonb, string for citext columns (#1229)
+  * Allow symbols for numericality options (#1258)
 
 ## 3.1.2
 

--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -207,6 +207,8 @@ module Formtastic
 
         private
 
+        # Loosely based on
+        # https://github.com/rails/rails/blob/5-2-stable/activemodel/lib/active_model/validations/numericality.rb#L54-L59
         def option_value(option, object)
           case option
           when Symbol

--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -223,4 +223,3 @@ module Formtastic
     end
   end
 end
-

--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -73,13 +73,11 @@ module Formtastic
             raise IndeterminableMinimumAttributeError if validation.options[:greater_than] && column? && [:float, :decimal].include?(column.type)
 
             if validation.options[:greater_than_or_equal_to]
-              return (validation.options[:greater_than_or_equal_to].call(object)) if validation.options[:greater_than_or_equal_to].kind_of?(Proc)
-              return (validation.options[:greater_than_or_equal_to])
+              return option_value(validation.options[:greater_than_or_equal_to], object)
             end
 
             if validation.options[:greater_than]
-              return (validation.options[:greater_than].call(object) + 1) if validation.options[:greater_than].kind_of?(Proc)
-              return (validation.options[:greater_than] + 1)
+              return option_value(validation.options[:greater_than], object) + 1
             end
           end
         end
@@ -94,13 +92,11 @@ module Formtastic
             raise IndeterminableMaximumAttributeError if validation.options[:less_than] && column? && [:float, :decimal].include?(column.type)
 
             if validation.options[:less_than_or_equal_to]
-              return (validation.options[:less_than_or_equal_to].call(object)) if validation.options[:less_than_or_equal_to].kind_of?(Proc)
-              return (validation.options[:less_than_or_equal_to])
+              return option_value(validation.options[:less_than_or_equal_to], object)
             end
 
             if validation.options[:less_than]
-              return ((validation.options[:less_than].call(object)) - 1) if validation.options[:less_than].kind_of?(Proc)
-              return (validation.options[:less_than] - 1)
+              return option_value(validation.options[:less_than], object) - 1
             end
           end
         end
@@ -207,6 +203,19 @@ module Formtastic
 
         def readonly_from_options?
           options[:input_html] && options[:input_html][:readonly]
+        end
+
+        private
+
+        def option_value(option, object)
+          case option
+          when Symbol
+            object.send(option)
+          when Proc
+            option.call(object)
+          else
+            option
+          end
         end
       end
     end

--- a/spec/inputs/base/validations_spec.rb
+++ b/spec/inputs/base/validations_spec.rb
@@ -338,5 +338,145 @@ RSpec.describe MyInput do
       end
     end
   end
+
+  describe '#validation_min' do
+    before :example do
+      allow(instance).to receive(:validations?).and_return(:true)
+      allow(instance).to receive(:validations).and_return([validator])
+    end
+
+    context 'with a greater_than numericality validator' do
+      let(:validator) { double(options: { greater_than: option_value }, kind: :numericality) }
+
+      context 'with a symbol' do
+        let(:option_value) { :a_symbol }
+
+        it 'returns one greater' do
+          allow(model).to receive(:send).with(option_value).and_return(14)
+          expect(instance.validation_min).to eq 15
+        end
+      end
+
+      context 'with a proc' do
+        let(:option_value) { Proc.new { 10 } }
+
+        it 'returns one greater' do
+          expect(instance.validation_min).to eq 11
+        end
+      end
+
+      context 'with a number' do
+        let(:option_value) { 8 }
+
+        it 'returns one greater' do
+          expect(instance.validation_min).to eq 9
+        end
+      end
+    end
+
+    context 'with a greater_than_or_equal_to numericality validator' do
+      let(:validator) do
+        double(
+          options: { greater_than_or_equal_to: option_value },
+          kind: :numericality
+        )
+      end
+
+      context 'with a symbol' do
+        let(:option_value) { :a_symbol }
+
+        it 'returns the instance method amount' do
+          allow(model).to receive(:send).with(option_value).and_return(14)
+          expect(instance.validation_min).to eq 14
+        end
+      end
+
+      context 'with a proc' do
+        let(:option_value) { Proc.new { 10 } }
+
+        it 'returns the proc amount' do
+          expect(instance.validation_min).to eq 10
+        end
+      end
+
+      context 'with a number' do
+        let(:option_value) { 8 }
+
+        it 'returns the number' do
+          expect(instance.validation_min).to eq 8
+        end
+      end
+    end
+  end
+
+  describe '#validation_max' do
+    before :example do
+      allow(instance).to receive(:validations?).and_return(:true)
+      allow(instance).to receive(:validations).and_return([validator])
+    end
+
+    context 'with a less_than numericality validator' do
+      let(:validator) { double(options: { less_than: option_value }, kind: :numericality) }
+
+      context 'with a symbol' do
+        let(:option_value) { :a_symbol }
+
+        it 'returns one less' do
+          allow(model).to receive(:send).with(option_value).and_return(14)
+          expect(instance.validation_max).to eq 13
+        end
+      end
+
+      context 'with a proc' do
+        let(:option_value) { proc { 10 } }
+
+        it 'returns one less' do
+          expect(instance.validation_max).to eq 9
+        end
+      end
+
+      context 'with a number' do
+        let(:option_value) { 8 }
+
+        it 'returns one less' do
+          expect(instance.validation_max).to eq 7
+        end
+      end
+    end
+
+    context 'with a less_than_or_equal_to numericality validator' do
+      let(:validator) do
+        double(
+          options: { less_than_or_equal_to: option_value },
+          kind: :numericality
+        )
+      end
+
+      context 'with a symbol' do
+        let(:option_value) { :a_symbol }
+
+        it 'returns the instance method amount' do
+          allow(model).to receive(:send).with(option_value).and_return(14)
+          expect(instance.validation_max).to eq 14
+        end
+      end
+
+      context 'with a proc' do
+        let(:option_value) { proc { 10 } }
+
+        it 'returns the proc amount' do
+          expect(instance.validation_max).to eq 10
+        end
+      end
+
+      context 'with a number' do
+        let(:option_value) { 8 }
+
+        it 'returns the number' do
+          expect(instance.validation_max).to eq 8
+        end
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
Rails allows symbols for these values but formtastic doesn't https://github.com/rails/rails/blob/v4.2.9/activemodel/lib/active_model/validations/numericality.rb#L55
