### PR TITLE
Add JSON Input for models with jsonb fields.

### DIFF
--- a/lib/formtastic/inputs.rb
+++ b/lib/formtastic/inputs.rb
@@ -21,6 +21,7 @@ module Formtastic
       autoload :EmailInput
       autoload :FileInput
       autoload :HiddenInput
+      autoload :JsonInput
       autoload :NumberInput
       autoload :NumericInput
       autoload :PasswordInput

--- a/lib/formtastic/inputs/json_input.rb
+++ b/lib/formtastic/inputs/json_input.rb
@@ -1,0 +1,37 @@
+module Formtastic
+  module Inputs
+
+    # Outputs a simple `<label>` with a `<input type="text">` wrapped in the standard
+    # `<li>` wrapper. This is the default input choice for database columns of the `:jsonb` type.
+    # You can force any input to be a string input with `:as => :json`.
+    #
+    # @example Full form context and output
+    #
+    #   <%= semantic_form_for(@user) do |f| %>
+    #     <%= f.inputs do %>
+    #       <%= f.input :preferences, :as => :json %>
+    #     <% end %>
+    #   <% end %>
+    #
+    #   <form...>
+    #     <fieldset>
+    #       <ol>
+    #         <li class="string">
+    #           <label for="user_preferences">Preferences</label>
+    #           <input type="text" id="user_preferences" name="user[preferences]" value="{\"preference1\":\"value1\"}">
+    #         </li>
+    #       </ol>
+    #     </fieldset>
+    #   </form>
+    #
+    # @see Formtastic::Helpers::InputsHelper#input InputsHelper#input for full documentation of all possible options.
+
+    class JsonInput < StringInput
+      def to_html
+        val = self.object.send(method)
+        self.object.send("#{method}=", JSON.generate(val))
+        super
+      end
+    end
+  end
+end

--- a/spec/inputs/json_input.rb
+++ b/spec/inputs/json_input.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe 'json input' do
+
+  include FormtasticSpecHelper
+
+  class ::Post
+    include ActiveModel
+
+    attr_accessor :author
+    def initialize(author)
+      @author = author
+    end
+  end
+
+  let(:author) { { 'name' => 'F. Scott Fitzgerald' } }
+  let(:post) { Post.new(author) }
+
+  before do
+    @output_buffer = ''
+    mock_everything
+
+    concat(semantic_form_for(post) do |builder|
+      concat(builder.input(:author, as: :json))
+    end)
+  end
+
+  it 'should generate json value' do
+    expect(output_buffer).to have_tag("[value='#{author.to_json}']")
+  end
+end


### PR DESCRIPTION
With ActiveRecord and a Postgres database, it's possible to have fields on a record that are actual JSON objects, rather than strings.

Currently, when Formtastic tries to render these fields in the admin interface, it renders them in the standard Ruby serialized hash format:

```ruby
{ "key1" => "value1" } { "key2" => "value2" }
```

This `JsonInput` allows the value of the field to be displayed as json:

```json
[{ "key1": "value1" }, { "key2": "value2" }]
```

This is helpful so that the value of the field can be edited directly, without the user/administrator 
first having to manually converting it from the Ruby serialized hash format to JSON.
