### PR TITLE
Add a selected option to datetime_select

### DIFF
--- a/lib/formtastic/inputs/base/timeish.rb
+++ b/lib/formtastic/inputs/base/timeish.rb
@@ -85,6 +85,9 @@ module Formtastic
       #   <%= f.input :publish_at, :as => :time_select, :include_blank => true %>
       #   <%= f.input :publish_at, :as => :time_select, :include_blank => false %>
       #
+      # @example Provide a value for the field via selected
+      #   <%= f.input :publish_at, :as => :datetime_select, :selected => DateTime.new(2018, 10, 4, 12, 00)
+      #
       # @todo Document i18n
       # @todo Check what other Rails options are supported (`start_year`, `end_year`, `use_month_numbers`, `use_short_month`, `add_month_numbers`, `prompt`), write tests for them, and otherwise support them
       # @todo Could we take the rendering from Rails' helpers and inject better HTML in and around it rather than re-inventing the whee?
@@ -157,7 +160,7 @@ module Formtastic
         end
         
         def value
-          object.send(method) if object && object.respond_to?(method)
+          input_options[:selected] || object.send(method) if object && object.respond_to?(method)
         end
         
         def fragment_input_html(fragment)

--- a/lib/formtastic/inputs/base/timeish.rb
+++ b/lib/formtastic/inputs/base/timeish.rb
@@ -160,7 +160,8 @@ module Formtastic
         end
         
         def value
-          input_options[:selected] || object.send(method) if object && object.respond_to?(method)
+          return input_options[:selected] if options.key?(:selected)
+          object.send(method) if object && object.respond_to?(method)
         end
         
         def fragment_input_html(fragment)

--- a/spec/inputs/date_select_input_spec.rb
+++ b/spec/inputs/date_select_input_spec.rb
@@ -156,7 +156,21 @@ RSpec.describe 'date select input' do
       expect(output_buffer).to have_tag('form li.date_select fieldset ol li label', :count => 0)
     end
   end
-  
+
+  describe ":selected option for setting a value" do
+    it "should set the selected value for the form" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:created_at, :as => :datetime_select, :selected => Date.new(2018, 10, 4)))
+        end
+      )
+
+      expect(output_buffer).to have_tag "option[value='2018'][selected='selected']"
+      expect(output_buffer).to have_tag "option[value='10'][selected='selected']"
+      expect(output_buffer).to have_tag "option[value='4'][selected='selected']"
+    end
+  end
+
   describe "when required" do
     it "should add the required attribute to the input's html options" do
       with_config :use_required_attribute, true do 

--- a/spec/inputs/datetime_select_input_spec.rb
+++ b/spec/inputs/datetime_select_input_spec.rb
@@ -165,7 +165,23 @@ RSpec.describe 'datetime select input' do
       expect(output_buffer).to have_tag('form li.datetime_select fieldset ol li label', :count => 0)
     end
   end
-  
+
+  describe ":selected option for setting a value" do
+    it "should set the selected value for the form" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:created_at, :as => :datetime_select, :selected => DateTime.new(2018, 10, 4, 12, 00)))
+        end
+      )
+
+      expect(output_buffer).to have_tag "option[value='2018'][selected='selected']"
+      expect(output_buffer).to have_tag "option[value='10'][selected='selected']"
+      expect(output_buffer).to have_tag "option[value='4'][selected='selected']"
+      expect(output_buffer).to have_tag "option[value='12'][selected='selected']"
+      expect(output_buffer).to have_tag "option[value='00'][selected='selected']"
+    end
+  end
+
   describe "when required" do
     it "should add the required attribute to the input's html options" do
       with_config :use_required_attribute, true do 

--- a/spec/inputs/time_select_input_spec.rb
+++ b/spec/inputs/time_select_input_spec.rb
@@ -185,6 +185,19 @@ RSpec.describe 'time select input' do
     end
   end
 
+  describe ":selected option for setting a value" do
+    it "should set the selected value for the form" do
+      concat(
+        semantic_form_for(@new_post) do |f|
+          concat(f.input(:created_at, :as => :datetime_select, :selected => DateTime.new(2018, 10, 4, 12, 00)))
+        end
+      )
+
+      expect(output_buffer).to have_tag "option[value='12'][selected='selected']"
+      expect(output_buffer).to have_tag "option[value='00'][selected='selected']"
+    end
+  end
+
   describe ':namespace option' do
     before do
       concat(semantic_form_for(@new_post, :namespace => 'form2') do |builder|


### PR DESCRIPTION
### Why?
- Previously, as far as I could tell, there was no way to set the value of a `datetime_select`, `date_select`, or `time_select` field. 

### What changed?
- In Rails, there is a `selected` option (documented [here](https://api.rubyonrails.org/classes/ActionView/Helpers/DateHelper.html#method-i-date_select)). I decided to follow that pattern and add a `selected` option to Formtastic that does the same thing.