### PR TITLE
Removes call to config option through explicit classname

### DIFF
--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -310,7 +310,7 @@ module Formtastic
       def default_columns_for_object
         cols  = association_columns(:belongs_to)
         cols += content_columns
-        cols -= Formtastic::FormBuilder.skipped_columns
+        cols -= skipped_columns
         cols.compact
       end
 

--- a/spec/builder/custom_builder_spec.rb
+++ b/spec/builder/custom_builder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do
 
   class MyCustomFormBuilder < Formtastic::FormBuilder
   end
-  
+
   # TODO should be a separate spec for custom inputs
   class Formtastic::Inputs::AwesomeInput
     include Formtastic::Inputs::Base
@@ -62,7 +62,7 @@ RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do
           expect(builder.class).to be(MyCustomFormBuilder)
         end
       end
-      
+
       # TODO should be a separate spec for custom inputs
       it "should allow me to call my custom input" do
         semantic_form_for(@new_post) do |builder|
@@ -73,10 +73,21 @@ RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do
       # See: https://github.com/justinfrench/formtastic/issues/657
       it "should not conflict with navigasmic" do
         allow_any_instance_of(self.class).to receive(:builder).and_return('navigasmic')
-        
+
         expect { semantic_form_for(@new_post) { |f| } }.not_to raise_error
       end
 
+      it "should use the custom builder's skipped_columns config for inputs" do
+        MyCustomFormBuilder.skipped_columns = [:title, :created_at]
+
+        concat(semantic_form_for(@new_post) do |builder|
+          concat(builder.inputs)
+        end)
+
+        expect(output_buffer).to_not have_tag('input#post_title')
+        expect(output_buffer).to_not have_tag('li#post_created_at_input')
+        expect(output_buffer).to have_tag('textarea#post_body')
+      end
     end
 
     describe "fields_for" do
@@ -86,7 +97,7 @@ RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do
         allow(@new_post).to receive(:comment_attributes=)
         semantic_form_for(@new_post, :builder => MyCustomFormBuilder) do |builder|
           expect(builder.class).to be(MyCustomFormBuilder)
-          
+
           builder.fields_for(:comment) do |nested_builder|
             expect(nested_builder.class).to be(MyCustomFormBuilder)
           end
@@ -94,6 +105,8 @@ RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do
       end
 
     end
+
+
 
   end
 

--- a/spec/builder/custom_builder_spec.rb
+++ b/spec/builder/custom_builder_spec.rb
@@ -78,9 +78,12 @@ RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do
       end
 
       it "should use the custom builder's skipped_columns config for inputs" do
-        MyCustomFormBuilder.skipped_columns = [:title, :created_at]
+        class AnotherCustomFormBuilder < Formtastic::FormBuilder
+          configure :skipped_columns, [:title, :created_at]
+        end
+        #AnotherCustomFormBuilder.skipped_columns = [:title, :created_at]
 
-        concat(semantic_form_for(@new_post) do |builder|
+        concat(semantic_form_for(@new_post, builder: AnotherCustomFormBuilder) do |builder|
           concat(builder.inputs)
         end)
 


### PR DESCRIPTION
[ActiveAdmin relies on a subclassing FormBuilder](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/form_builder.rb). For remotely related reasons I also need to set the skipped_columns option only for that subclass but the explicit call to ``Formtastic::FormBuilder.skipped_columns`` [here](https://github.com/justinfrench/formtastic/blob/ebd9b6627e1ee867347094cb7488292ce69d01a6/lib/formtastic/helpers/inputs_helper.rb#L313) prevents me from doing that. 

General question: Should I be able to copy the config when subclassing from FormBuilder to be able to alter it's behaviour? Or should there be only one global config. 

For my very specific problem: Removing the explicit reference to the class actually works quite fine (except that a future dev might have trouble finding out where ``skipped_columns`` came from)