### PR TITLE
Macro method usage change for Mongoid 7.0

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -12,6 +12,7 @@ module Formtastic
   autoload :InputClassFinder
   autoload :ActionClassFinder
   autoload :Deprecation
+  autoload :Reflection
 
   eager_autoload do
     autoload :I18n

--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -336,7 +336,8 @@ module Formtastic
       # generated input.
       def association_columns(*by_associations) # @private
         if @object.present? && @object.class.respond_to?(:reflections)
-          @object.class.reflections.collect do |name, association_reflection|
+          @object.class.reflections.collect do |name, reflection|
+            association_reflection = Formtastic::Reflection.new(reflection)
             if by_associations.present?
               if by_associations.include?(association_reflection.macro) && association_reflection.options[:polymorphic] != true
                 name

--- a/lib/formtastic/helpers/reflection.rb
+++ b/lib/formtastic/helpers/reflection.rb
@@ -6,9 +6,9 @@ module Formtastic
       # reflection object.
       def reflection_for(method) # @private
         if @object.class.respond_to?(:reflect_on_association)
-          @object.class.reflect_on_association(method)
+          reflection_on_association @object.class.reflect_on_association(method)
         elsif @object.class.respond_to?(:associations) # MongoMapper uses the 'associations(method)' instead
-          @object.class.associations[method]
+          reflection_on_association @object.class.associations[method]
         end
       end
 
@@ -19,18 +19,15 @@ module Formtastic
 
       def association_primary_key_for_method(method) # @private
         reflection = reflection_for(method)
-        if reflection
-          case association_macro_for_method(method)
-          when :has_and_belongs_to_many, :has_many, :references_and_referenced_in_many, :references_many
-            :"#{method.to_s.singularize}_ids"
-          else
-            return reflection.foreign_key.to_sym if reflection.respond_to?(:foreign_key)
-            return reflection.options[:foreign_key].to_sym unless reflection.options[:foreign_key].blank?
-            :"#{method}_id"
-          end
-        else
-          method.to_sym
-        end
+        reflection ? reflection.primary_key : method.to_sym
+      end
+
+      private
+
+      def reflection_on_association(reflection)
+        return unless reflection
+
+        Formtastic::Reflection.new(reflection)
       end
     end
   end

--- a/lib/formtastic/reflection.rb
+++ b/lib/formtastic/reflection.rb
@@ -1,0 +1,35 @@
+module Formtastic
+  class Reflection
+    delegate :options, :klass, to: :@_reflection
+    attr_reader :_reflection
+
+     def initialize(reflection)
+      @_reflection = reflection
+    end
+
+     def macro
+      respond_to_macro? ? _reflection.macro : macro_from_class
+    end
+
+     def primary_key
+      case macro
+      when :has_and_belongs_to_many, :has_many, :references_and_referenced_in_many, :references_many
+        :"#{_reflection.name.to_s.singularize}_ids"
+      else
+        return _reflection.foreign_key.to_sym if _reflection.respond_to?(:foreign_key)
+        return _reflection.options[:foreign_key].to_sym unless _reflection.options[:foreign_key].blank?
+        :"#{_reflection.name}_id"
+      end
+    end
+
+     def respond_to_macro?
+      _reflection.respond_to(:macro)
+    end
+
+     private
+
+     def macro_from_class
+      _reflection.class.name.demodulize.underscore.to_sym
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** Mongoid with 7.0 patch removed file which contained `macro` method. Formtastic gem relies on this method in various places in code. Currently, projects which use Mongo 7.0 are having `undefined 'macro' method` error.
  - File path which contains `macro` method: https://github.com/mongodb/mongoid/blob/v6.4.4/lib/mongoid/relations/referenced/in.rb
  - A path where removed `relations` folder and forward files - removed: https://github.com/mongodb/mongoid/tree/v7.0.0/lib/mongoid

**Solution:** To avoid breaking current macro usage and fix the error for Mongoid 7.0 database based projects, a solution with `Proxy Object` was introduced in this pull request. Using Proxy Object allowed fixing macro method issue while keeping gem mostly intact. In the future, if other special issues will appear with the reflection object, fixing them will be easier by modifying this class.