### PR TITLE
Drop support for old rubies under 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
     - vendor/bundle
 language: ruby
 rvm:
-  - 2.2.9
-  - 2.3.6
   - 2.4.3
   - 2.5.0
 gemfile:
@@ -27,10 +25,6 @@ script:
  - script/integration.sh
 matrix:
   exclude:
-    - rvm: 2.2.9
-      gemfile: gemfiles/rails_edge.gemfile
-    - rvm: 2.3.6
-      gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.4.3
       gemfile: gemfiles/rails_4.1.gemfile
     - rvm: 2.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Changed required Ruby version to >= 2.0 (#1210)
   * Default to input types text for json & jsonb, string for citext columns (#1229)
   * Allow symbols for numericality options (#1258)
+  * Support for rubies under 2.4.0 has been dropped (#1292)
 
 ## 3.1.2
 

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.rubygems_version = %q{1.3.6}
 


### PR DESCRIPTION
Since they are no longer maintained.