### PR TITLE
Travis config improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ cache:
   - bundler
   - directories:
     - vendor/bundle
+dist: bionic
 language: ruby
 rvm:
   - 2.4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
     - vendor/bundle
 dist: bionic
 language: ruby
+node_js: 11
 rvm:
   - 2.4.9
   - 2.5.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ gemfile:
   - gemfiles/rails_5.2.gemfile
   - gemfiles/rails_edge.gemfile
 before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '< 2'
+  - gem install bundler
   - export BUNDLE_PATH="${TRAVIS_BUILD_DIR}/vendor/bundle"
 before_cache:
   - rm -f ${BUNDLE_PATH}/**/extensions/**/{gem_make.out,mkmf.log}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 cache:
   - bundler
   - directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_install:
 before_cache:
   - rm -f ${BUNDLE_PATH}/**/extensions/**/{gem_make.out,mkmf.log}
 script:
- - bundle exec rake spec
- - script/integration.sh
+  - bundle exec rake spec
+  - script/integration.sh
 matrix:
   allow_failures:
     - gemfile: gemfiles/rails_edge.gemfile


### PR DESCRIPTION
This PR allows bundler 2 to be used in CI (since our range of supported rubies matches now what bundler 2 supports) and adds a few other improvements to the configuration.