### PR TITLE
Fix appraisal generate

### DIFF
--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.2.0", github: "rails/rails", branch: "5-2-stable"
+gem "rails", "~> 5.2.0"
 
 gemspec path: "../"


### PR DESCRIPTION
Currently `bundle exec appraisal generate` generates some source control changes.

This change gets the result of that command in sync with what we have under version control.