### PR TITLE
Fix eager loading problem

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -18,7 +18,6 @@ module Formtastic
     autoload :FormBuilder
     autoload :Inputs
     autoload :Actions
-    autoload :Util
   end
 
   # @public


### PR DESCRIPTION
Caused by cbbff9c7 which removed `formtastic/util.rb` but not the corresponding `autoload :Util` statement.