### PR TITLE
Remove deprecation warning for Ruby 2.7

### DIFF
--- a/lib/formtastic/localizer.rb
+++ b/lib/formtastic/localizer.rb
@@ -101,7 +101,7 @@ module Formtastic
             # This is effectively what Rails label helper does for i18n lookup
             options[:scope] = [:helpers, type]
             options[:default] = defaults
-            i18n_value = ::I18n.t(default_key, options)
+            i18n_value = ::I18n.t(default_key, **options)
           end
 
           # save the result to the cache


### PR DESCRIPTION
Ruby 2.7 has deprecated passing the last argument as a keyword parameter. https://bugs.ruby-lang.org/issues/14183

Fixes this deprecation warning
```
formtastic/lib/formtastic/localizer.rb:105: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/i18n-1.8.2/lib/i18n.rb:195: warning: The called method `t' is defined here
```
The fix is backwards compatible with Ruby < 2.7