### PR TITLE
Remove ruby 2.7 deprecation warning

### DIFF
--- a/lib/formtastic/i18n.rb
+++ b/lib/formtastic/i18n.rb
@@ -23,7 +23,7 @@ module Formtastic
         options = args.extract_options!
         options.reverse_merge!(:default => DEFAULT_VALUES[key])
         options[:scope] = [DEFAULT_SCOPE, options[:scope]].flatten.compact
-        ::I18n.translate(key, *(args << options))
+        ::I18n.translate(key, *args, **options)
       end
       alias :t :translate
 


### PR DESCRIPTION
```
/path/to/formtastic-f95dddae2fe5/lib/formtastic/i18n.rb:26: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/i18n-1.8.2/lib/i18n.rb:195: warning: The called method `translate' is defined here
```