### PR TITLE
Change `semantic_errors` to render all errors by default

### DIFF
--- a/lib/formtastic/form_builder.rb
+++ b/lib/formtastic/form_builder.rb
@@ -48,6 +48,7 @@ module Formtastic
     configure :priority_time_zones, []
     configure :required_string, proc { %{<abbr title="#{Formtastic::I18n.t(:required)}">*</abbr>}.html_safe }
     configure :semantic_errors_link_to_inputs, false
+    configure :semantic_errors_render_all_attributes, false
     configure :skipped_columns, [:created_at, :updated_at, :created_on, :updated_on, :lock_version, :version]
     configure :use_required_attribute, false
 

--- a/lib/formtastic/helpers/errors_helper.rb
+++ b/lib/formtastic/helpers/errors_helper.rb
@@ -9,7 +9,7 @@ module Formtastic
       INLINE_ERROR_TYPES = [:sentence, :list, :first]
 
       # Generates an unordered list of error messages on the base object and optionally for a given
-      # set of named attribute. This is idea for rendering a block of error messages at the top of
+      # set of named attributes. This is ideal for rendering a block of error messages at the top of
       # the form for hidden/special/virtual attributes (the Paperclip Rails plugin does this), or
       # errors on the base model.
       #
@@ -19,6 +19,8 @@ module Formtastic
       # # in config/initializers/formtastic.rb
       # Setting `Formtastic::FormBuilder.semantic_errors_link_to_inputs = true`
       # will render attribute errors as links to the corresponding errored inputs.
+      # Setting `Formtastic::FormBuilder.semantic_errors_render_all_attributes = true`
+      # will render base errors and all errored attributes when no arguments are passed
       #
       # @example A list of errors on the base model
       #   <%= semantic_form_for ... %>
@@ -43,9 +45,18 @@ module Formtastic
       #     <%= f.semantic_errors :something_special, :something_else, :class => "awesome", :onclick => "Awesome();" %>
       #     ...
       #   <% end %>
+      #
+      # @param [Array<Symbol>] *args Optional attribute names to display errors for.
+      #   When empty, displays base errors or full errors based on configuration. HTML options can be passed
+      #   as the last argument hash.
+      # @return [String, nil] HTML string containing error list, or nil if no errors exist
       def semantic_errors(*args)
         html_options = args.extract_options!
         html_options[:class] ||= "errors"
+
+        if Formtastic::FormBuilder.semantic_errors_render_all_attributes && args.empty?
+          args = @object.errors.attribute_names
+        end
 
         if Formtastic::FormBuilder.semantic_errors_link_to_inputs
           attribute_error_hash = semantic_error_hash_from_attributes(args)

--- a/lib/generators/templates/formtastic.rb
+++ b/lib/generators/templates/formtastic.rb
@@ -116,3 +116,8 @@
 # the errored input's aria-describedby. This ensures that the errored input is read out with
 # the inline error sentence's error explanation, aria-invalid is set to true for errored inputs
 # Formtastic::FormBuilder.semantic_errors_link_to_inputs = true
+
+# You can opt into rendering all errors (base and attribute errors) when no arguments are passed to
+# <%= form.semantic_errors %>
+# Default is false, and will only render base errors when no arguments are passed to `semantic_errors`.
+# Formtastic::FormBuilder.semantic_errors_render_all_attributes = true

--- a/spec/helpers/semantic_errors_helper_spec.rb
+++ b/spec/helpers/semantic_errors_helper_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
   describe 'when there is only one error on base' do
     before do
       allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_error)
+      allow(@errors).to receive(:attribute_names).and_return([:base])
     end
 
     it 'should render an unordered list' do
@@ -30,6 +31,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
   describe 'when there is more than one error on base' do
     before do
       allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_errors)
+      allow(@errors).to receive(:attribute_names).and_return([:base])
     end
 
     it 'should render an unordered list' do
@@ -46,6 +48,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     before do
       allow(@errors).to receive(:[]).with(errors_matcher(:title)).and_return(@title_errors)
       allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return([])
+      allow(@errors).to receive(:attribute_names).and_return([:title])
     end
 
     it 'should render an unordered list' do
@@ -60,6 +63,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     before do
       allow(@errors).to receive(:[]).with(errors_matcher(:title)).and_return(@title_errors)
       allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_error)
+      allow(@errors).to receive(:attribute_names).and_return([:title, :base])
     end
 
     it 'should render an unordered list' do
@@ -75,6 +79,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     before do
       allow(@errors).to receive(:[]).with(errors_matcher(:title)).and_return([])
       allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return([])
+      allow(@errors).to receive(:attribute_names).and_return([])
     end
 
     it 'should return nil' do
@@ -87,6 +92,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
   describe 'when there is one error on base and options with class is passed' do
     before do
       allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_error)
+      allow(@errors).to receive(:attribute_names).and_return([])
     end
 
     it 'should render an unordered list with given class' do
@@ -99,12 +105,73 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
   describe 'when :base is passed in as an argument' do
     before do
       allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_error)
+      allow(@errors).to receive(:attribute_names).and_return([:base])
     end
 
     it 'should ignore :base and only render base errors once' do
       semantic_form_for(@new_post) do |builder|
         expect(builder.semantic_errors(:base)).to have_tag('ul li', :count => 1)
         expect(builder.semantic_errors(:base)).not_to have_tag('ul li', :text => "Base #{@base_error}")
+      end
+    end
+  end
+
+  describe 'when no attribute args or base are passed' do
+    before do
+      @author = AuthorWithValidations.new(name: 'a', surname: 'b', login: 'asdf')
+      @author.valid?
+      @author.errors.add(:base, 'Base error')
+    end
+
+    context 'when Formtastic::FormBuilder.semantic_errors_render_all_attributes is true' do
+      before do
+        Formtastic::FormBuilder.semantic_errors_render_all_attributes = true
+      end
+
+      after do
+        Formtastic::FormBuilder.semantic_errors_render_all_attributes = false
+      end
+
+      it 'should render base and all errors when no args are passed' do
+        semantic_form_for(@author) do |builder|
+          without_args = builder.semantic_errors
+
+          expect(without_args).to have_tag('li', text: /Name.*too short/, count: 1)
+          expect(without_args).to have_tag('li', text: /Surname.*too short/, count: 1)
+          expect(without_args).to have_tag('li', text: /Login.*too short/, count: 1)
+          expect(without_args).to have_tag('li', text: /Base error/, count: 1)
+        end
+      end
+
+      it 'should render base and all errors when no args are passed with custom HTML options' do
+        semantic_form_for(@author) do |builder|
+          with_opts = builder.semantic_errors(class: 'custom-errors', id: 'error-summary', data: { controller: 'awesome' })
+
+          expect(with_opts).to have_tag('ul.custom-errors#error-summary[data-controller="awesome"]')
+          expect(with_opts).to have_tag('li', text: /Name.*too short/, count: 1)
+          expect(with_opts).to have_tag('li', text: /Surname.*too short/, count: 1)
+          expect(with_opts).to have_tag('li', text: /Login.*too short/, count: 1)
+          expect(with_opts).to have_tag('li', text: /Base error/, count: 1)
+        end
+      end
+    end # context 'when Formtastic::FormBuilder.semantic_errors_render_all_attributes is true'
+
+    it 'should render base errors when no args are passed' do
+      semantic_form_for(@author) do |builder|
+        without_args = builder.semantic_errors
+
+        expect(without_args).not_to have_tag('li', text: /Login.*too short/, count: 1)
+        expect(without_args).to have_tag('li', text: /Base error/, count: 1)
+      end
+    end
+
+    it 'should render base errors when no args are passed with custom HTML options' do
+      semantic_form_for(@author) do |builder|
+        with_opts = builder.semantic_errors(class: 'custom-errors', id: 'error-summary', data: { controller: 'awesome' })
+
+        expect(with_opts).to have_tag('ul.custom-errors#error-summary[data-controller="awesome"]')
+        expect(with_opts).not_to have_tag('li', text: /Login.*too short/, count: 1)
+        expect(with_opts).to have_tag('li', text: /Base error/, count: 1)
       end
     end
   end
@@ -122,6 +189,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     describe 'when there is only one error on base' do
       before do
         allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_error)
+        allow(@errors).to receive(:attribute_names).and_return([])
       end
 
       it 'should render an unordered list' do
@@ -134,6 +202,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     describe 'when there is more than one error on base' do
       before do
         allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_errors)
+        allow(@errors).to receive(:attribute_names).and_return([:base])
       end
 
       it 'should render an unordered list' do
@@ -150,6 +219,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
       before do
         allow(@errors).to receive(:[]).with(errors_matcher(:title)).and_return(@title_errors)
         allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return([])
+        allow(@errors).to receive(:attribute_names).and_return([:base, :title])
       end
 
       it 'should render an unordered list' do
@@ -164,6 +234,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
       before do
         allow(@errors).to receive(:[]).with(errors_matcher(:title)).and_return(@title_errors)
         allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_error)
+        allow(@errors).to receive(:attribute_names).and_return([:base, :title])
       end
 
       it 'should render an unordered list where base has no link, and title error attribute links to title input field' do
@@ -183,6 +254,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
       before do
         allow(@errors).to receive(:[]).with(errors_matcher(:title)).and_return([])
         allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return([])
+        allow(@errors).to receive(:attribute_names).and_return([])
       end
 
       it 'should return nil' do
@@ -195,6 +267,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     describe 'when there is one error on base and options with class is passed' do
       before do
         allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_error)
+        allow(@errors).to receive(:attribute_names).and_return([])
       end
 
       it 'should render an unordered list with given class' do
@@ -207,12 +280,72 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     describe 'when :base is passed in as an argument' do
       before do
         allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(@base_error)
+        allow(@errors).to receive(:attribute_names).and_return([])
       end
 
       it 'should ignore :base and only render base errors once' do
         semantic_form_for(@new_post) do |builder|
           expect(builder.semantic_errors(:base)).to have_tag('ul li', count: 1)
           expect(builder.semantic_errors(:base)).not_to have_tag('ul li', text: "Base #{@base_error}")
+        end
+      end
+    end
+
+    describe 'when no attribute args or base are passed' do
+      before do
+        @author = AuthorWithValidations.new(name: 'a', surname: 'b', login: 'asdf')
+        @author.valid?
+        @author.errors.add(:base, 'Base error')
+      end
+
+      context 'when Formtastic::FormBuilder.semantic_errors_render_all_attributes is true' do
+        before do
+          Formtastic::FormBuilder.semantic_errors_render_all_attributes = true
+        end
+
+        after do
+          Formtastic::FormBuilder.semantic_errors_render_all_attributes = false
+        end
+
+        it 'should render base and all errors when no args are passed' do
+          semantic_form_for(@author) do |builder|
+            without_args = builder.semantic_errors
+
+            expect(without_args).to have_tag('ul.errors li a', text: /Name.*too short/, count: 1)
+            expect(without_args).to have_tag('ul.errors li a', text: /Surname.*too short/, count: 1)
+            expect(without_args).to have_tag('ul.errors li a', text: /Login.*too short/, count: 1)
+            expect(without_args).to have_tag('ul.errors li', text: /Base error/, count: 1)
+          end
+        end
+
+        it 'should render base and all errors when no args are passed with custom HTML options' do
+          semantic_form_for(@author) do |builder|
+            with_opts = builder.semantic_errors(class: 'custom-errors', id: 'error-summary', data: { role: 'alert' })
+
+            expect(with_opts).to have_tag('ul.custom-errors#error-summary[data-role="alert"]')
+            expect(with_opts).to have_tag('ul.custom-errors li a', text: /Name.*too short/, count: 1)
+            expect(with_opts).to have_tag('ul.custom-errors li a', text: /Surname.*too short/, count: 1)
+            expect(with_opts).to have_tag('ul.custom-errors li a', text: /Login.*too short/, count: 1)
+            expect(with_opts).to have_tag('ul.custom-errors li', text: /Base error/, count: 1)
+          end
+        end
+      end # context 'when Formtastic::FormBuilder.semantic_errors_render_all_attributes is true'
+
+      it 'should render base and all errors when no args are passed' do
+        semantic_form_for(@author) do |builder|
+          without_args = builder.semantic_errors
+
+          expect(without_args).not_to have_tag('ul.errors li a', text: /Login.*too short/, count: 1)
+          expect(without_args).to have_tag('ul.errors li', text: /Base error/, count: 1)
+        end
+      end
+
+      it 'should render base and all errors when no args are passed with custom HTML options' do
+        semantic_form_for(@author) do |builder|
+          with_opts = builder.semantic_errors(class: 'custom-errors', id: 'error-summary', data: { role: 'alert' })
+
+          expect(with_opts).not_to have_tag('ul.custom-errors li a', text: /Login.*too short/, count: 1)
+          expect(with_opts).to have_tag('ul.custom-errors li', text: /Base error/, count: 1)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,10 +41,10 @@ module FormtasticSpecHelper
   include ActionView::Helpers::AssetTagHelper
   include ActiveSupport
   include ActionController::PolymorphicRoutes if defined?(ActionController::PolymorphicRoutes)
-  include ActionDispatch::Routing::PolymorphicRoutes 
+  include ActionDispatch::Routing::PolymorphicRoutes
   include AbstractController::UrlFor if defined?(AbstractController::UrlFor)
   include ActionView::RecordIdentifier if defined?(ActionView::RecordIdentifier)
-  
+
   include Formtastic::Helpers::FormHelper
 
   def default_input_type(column_type, column_name = :generic_column_name)
@@ -117,6 +117,12 @@ module FormtasticSpecHelper
     end
   end
 
+  class ::AuthorWithValidations < Author
+    validates :name, presence: true, length: { minimum: 2 }
+    validates :surname, presence: true, length: { minimum: 2 }
+    validates :login, presence: true, length: { minimum: 8 }
+  end
+
   class ::HashBackedAuthor < Hash
     extend ActiveModel::Naming if defined?(ActiveModel::Naming)
     include ActiveModel::Conversion if defined?(ActiveModel::Conversion)
@@ -151,49 +157,49 @@ module FormtasticSpecHelper
       sym == :options ? false : super
     end
   end
-  
+
   # Model.all returns an association proxy, which quacks a lot like an array.
   # We use this in stubs or mocks where we need to return the later.
-  # 
+  #
   # TODO try delegate?
   # delegate :map, :size, :length, :first, :to_ary, :each, :include?, :to => :array
   class MockScope
     attr_reader :array
-    
+
     def initialize(the_array)
       @array = the_array
     end
-    
+
     def map(&block)
       array.map(&block)
     end
-    
+
     def where(*args)
       # array
       self
     end
-    
+
     def includes(*args)
       self
     end
-    
+
     def size
       array.size
     end
     alias_method :length, :size
-    
+
     def first
       array.first
     end
-    
+
     def to_ary
       array
     end
-    
+
     def each(&block)
       array.each(&block)
     end
-    
+
     def include?(*args)
       array.include?(*args)
     end
@@ -236,7 +242,8 @@ module FormtasticSpecHelper
     def author_path(*args); "/authors/1"; end
     def authors_path(*args); "/authors"; end
     def new_author_path(*args); "/authors/new"; end
-    
+    def author_with_validations_index_path(*args); "/authors"; end
+
     def author_array_or_scope(the_array = [@fred, @bob])
       MockScope.new(the_array)
     end
@@ -249,7 +256,7 @@ module FormtasticSpecHelper
     allow(::Author).to receive(:find).and_return(author_array_or_scope)
     allow(::Author).to receive(:all).and_return(author_array_or_scope)
     allow(::Author).to receive(:where).and_return(author_array_or_scope)
-    allow(::Author).to receive(:human_attribute_name) { |column_name| column_name.humanize }
+    allow(::Author).to receive(:human_attribute_name) { |column_name| column_name.to_s.humanize }
     allow(::Author).to receive(:human_name).and_return('::Author')
     allow(::Author).to receive(:reflect_on_association) { |column_name| double('reflection', :scope => nil, :options => {}, :klass => Post, :macro => :has_many) if column_name == :posts }
     allow(::Author).to receive(:content_columns).and_return([double('column', :name => 'login'), double('column', :name => 'created_at')])
@@ -443,7 +450,7 @@ module FormtasticSpecHelper
     yield
     Formtastic::FormBuilder.send(:"#{config_method_name}=", old_value)
   end
-  
+
   RSpec::Matchers.define :errors_matcher do |expected|
     match { |actual| actual.to_s == expected.to_s }
   end
@@ -461,6 +468,6 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.before(:example) do
-    Formtastic::Localizer.cache.clear!    
+    Formtastic::Localizer.cache.clear!
   end
 end


### PR DESCRIPTION
Idea for solving #1396 

This will alter the default behavior of `semantic_errors`, instead `:base` being the default, if no args are passed, the `form.semantic_errors` helper will render all base and errored attributes.

I added some test objects without mocking, since I wanted to see an active model record's messaging by default.

Did some experimenting in a Rails 8 app console about `attribute_names`
```
 b = Book.new(synopsis: 'fake @@@')
=> 
#<Book:0x0000000111531558
...
formtastic-inline-errors(dev)> b.errors.attribute_names
=> []
formtastic-inline-errors(dev)> b.valid?
=> false
formtastic-inline-errors(dev)> b.errors.attribute_names
 b.errors.class
=> ActiveModel::Errors
formtastic-inline-errors(dev)> b.errors.attribute_names
=> [:title, :isbn, :base, :synopsis]
```

So I think the `attribute_names` should be safe to use, are there other types of classes passed to formtastic that wouldnt be ActiveModel::Errors?