### PR TITLE
add wrapper_tag option

### DIFF
--- a/lib/formtastic/inputs/base/wrapping.rb
+++ b/lib/formtastic/inputs/base/wrapping.rb
@@ -8,7 +8,7 @@ module Formtastic
         # Override this method if you want to change the display order (for example, rendering the
         # errors before the body of the input).
         def input_wrapping(&block)
-          template.content_tag(:li,
+          template.content_tag(options.fetch(:wrapper_tag, :li),
             [template.capture(&block), error_html, hint_html].join("\n").html_safe,
             wrapper_html_options
           )


### PR DESCRIPTION
Add a possibility to change wrapping <li> to anything else, based on https://github.com/formtastic/formtastic/issues/625 discussion